### PR TITLE
feat(plugin): rename cdylib output to libcoding_agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ All components are installed under `~/.coding-agents-kit/`:
 │   └── falco.coding_agents_plugin.yaml  # Plugin config (plugin def, rules, http_output)
 ├── log/                    # Falco logs: falco.log (stdout), falco.err (stderr)
 ├── run/                    # Runtime: broker.sock
-├── share/                  # Shared libraries: libcoding_agent_plugin.so (.dylib on macOS)
+├── share/                  # Shared libraries: libcoding_agent.so (.dylib on macOS)
 └── rules/
     ├── default/
     │   └── coding_agents_rules.yaml  # Default ruleset (overwritten on upgrade)
@@ -306,7 +306,7 @@ cargo build --release     # .so (Linux) or .dylib (macOS) at target/release/
 # Verify with Falco
 falco -o "engine.kind=nodriver" \
   -o "plugins[0].name=coding_agent" \
-  -o "plugins[0].library_path=$(pwd)/target/release/libcoding_agent_plugin.so" \
+  -o "plugins[0].library_path=$(pwd)/target/release/libcoding_agent.so" \
   -o 'plugins[0].init_config={}' \
   -o "load_plugins[0]=coding_agent" \
   --plugin-info coding_agent

--- a/configs/falco.coding_agents_plugin.yaml
+++ b/configs/falco.coding_agents_plugin.yaml
@@ -3,7 +3,7 @@
 
 plugins:
   - name: coding_agent
-    library_path: ${HOME}/.coding-agents-kit/share/libcoding_agent_plugin.so
+    library_path: ${HOME}/.coding-agents-kit/share/libcoding_agent.so
     init_config:
       # Operational mode: "enforcement" (default) or "monitor".
       # In monitor mode, rules are evaluated and logged but all verdicts resolve as allow.

--- a/docs/plugins/coding-agent-plugin/SPEC.md
+++ b/docs/plugins/coding-agent-plugin/SPEC.md
@@ -3,7 +3,7 @@
 | Field    | Value                        |
 |----------|------------------------------|
 | Version  | 0.1.0                        |
-| Library  | `libcoding_agent_plugin.so`  |
+| Library  | `libcoding_agent.so`  |
 | Source   | `plugins/coding-agent-plugin/` |
 | Language | Rust (falco_plugin SDK v0.5) |
 

--- a/installers/linux/README.md
+++ b/installers/linux/README.md
@@ -61,7 +61,7 @@ If `dialog` is available, the installer provides an interactive confirmation pro
 ├── bin/                    # falco, claude-interceptor, coding-agents-kit-ctl
 ├── config/                 # falco.yaml, falco.coding_agents_plugin.yaml
 ├── run/                    # broker.sock (runtime)
-├── share/                  # libcoding_agent_plugin.so
+├── share/                  # libcoding_agent.so
 └── rules/
     ├── default/            # Default rules (overwritten on upgrade)
     ├── user/               # Custom rules (preserved on upgrade)

--- a/installers/linux/install.sh
+++ b/installers/linux/install.sh
@@ -58,7 +58,7 @@ run() {
 
 # Verify we have the package contents.
 for f in bin/falco bin/claude-interceptor bin/coding-agents-kit-ctl \
-         share/libcoding_agent_plugin.so \
+         share/libcoding_agent.so \
          config/falco.yaml config/falco.coding_agents_plugin.yaml \
          rules/seen.yaml systemd/coding-agents-kit.service; do
     [[ -f "$SCRIPT_DIR/$f" ]] || err "Missing package file: $f (are you running from the extracted package?)"
@@ -119,7 +119,7 @@ run install -m 755 "$SCRIPT_DIR/bin/claude-interceptor" "$PREFIX/bin/claude-inte
 run install -m 755 "$SCRIPT_DIR/bin/coding-agents-kit-ctl" "$PREFIX/bin/coding-agents-kit-ctl"
 
 info "Installing plugin..."
-run install -m 644 "$SCRIPT_DIR/share/libcoding_agent_plugin.so" "$PREFIX/share/libcoding_agent_plugin.so"
+run install -m 644 "$SCRIPT_DIR/share/libcoding_agent.so" "$PREFIX/share/libcoding_agent.so"
 
 info "Installing configuration..."
 run install -m 644 "$SCRIPT_DIR/config/falco.yaml" "$PREFIX/config/falco.yaml"
@@ -186,7 +186,7 @@ echo ""
 echo "  Install prefix:  $PREFIX"
 echo "  Falco binary:    $PREFIX/bin/falco"
 echo "  Interceptor:     $PREFIX/bin/claude-interceptor"
-echo "  Plugin:          $PREFIX/share/libcoding_agent_plugin.so"
+echo "  Plugin:          $PREFIX/share/libcoding_agent.so"
 echo "  Config:          $PREFIX/config/"
 echo "  Rules:           $PREFIX/rules/"
 echo "  User rules:      $PREFIX/rules/user/ (add custom rules here)"

--- a/installers/linux/package.sh
+++ b/installers/linux/package.sh
@@ -46,13 +46,13 @@ if [[ "$ARCH" == "$HOST_ARCH" ]]; then
     # Native build — no cross-compilation flags needed.
     CARGO_TARGET_FLAG=""
     INTERCEPTOR_BIN="hooks/claude-code/target/release/claude-interceptor"
-    PLUGIN_LIB="plugins/coding-agent-plugin/target/release/libcoding_agent_plugin.so"
+    PLUGIN_LIB="plugins/coding-agent-plugin/target/release/libcoding_agent.so"
     CTL_BIN="tools/coding-agents-kit-ctl/target/release/coding-agents-kit-ctl"
 else
     # Cross-compilation.
     CARGO_TARGET_FLAG="--target $RUST_TARGET"
     INTERCEPTOR_BIN="hooks/claude-code/target/$RUST_TARGET/release/claude-interceptor"
-    PLUGIN_LIB="plugins/coding-agent-plugin/target/$RUST_TARGET/release/libcoding_agent_plugin.so"
+    PLUGIN_LIB="plugins/coding-agent-plugin/target/$RUST_TARGET/release/libcoding_agent.so"
     CTL_BIN="tools/coding-agents-kit-ctl/target/$RUST_TARGET/release/coding-agents-kit-ctl"
 fi
 
@@ -93,7 +93,7 @@ mkdir -p "$BUILD_DIR"/{bin,share,config,rules/default,rules/user,systemd}
 # Binaries.
 cp "$ROOT_DIR/$INTERCEPTOR_BIN" "$BUILD_DIR/bin/claude-interceptor"
 cp "$ROOT_DIR/$CTL_BIN" "$BUILD_DIR/bin/coding-agents-kit-ctl"
-cp "$ROOT_DIR/$PLUGIN_LIB" "$BUILD_DIR/share/libcoding_agent_plugin.so"
+cp "$ROOT_DIR/$PLUGIN_LIB" "$BUILD_DIR/share/libcoding_agent.so"
 
 # Extract only falco binary from the tarball.
 tar xzf "$FALCO_CACHE" --strip-components=3 -C "$BUILD_DIR/bin/" \

--- a/installers/macos/README.md
+++ b/installers/macos/README.md
@@ -107,7 +107,7 @@ xattr -dr com.apple.quarantine ~/.coding-agents-kit/bin/*
 ├── config/                 # falco.yaml, falco.coding_agents_plugin.yaml
 ├── log/                    # falco.log (stdout), falco.err (stderr)
 ├── run/                    # broker.sock (runtime)
-├── share/                  # libcoding_agent_plugin.dylib
+├── share/                  # libcoding_agent.dylib
 └── rules/
     ├── default/            # Default rules (overwritten on upgrade)
     ├── user/               # Custom rules (preserved on upgrade)

--- a/installers/macos/install.sh
+++ b/installers/macos/install.sh
@@ -77,7 +77,7 @@ fi
 
 # Verify we have the package contents.
 for f in bin/falco bin/claude-interceptor bin/coding-agents-kit-ctl \
-         share/libcoding_agent_plugin.dylib \
+         share/libcoding_agent.dylib \
          config/falco.yaml config/falco.coding_agents_plugin.yaml \
          rules/seen.yaml launchd/dev.falcosecurity.coding-agents-kit.plist \
          launchd/coding-agents-kit-launcher.sh; do
@@ -131,7 +131,7 @@ run install -m 755 "$SCRIPT_DIR/bin/claude-interceptor" "$PREFIX/bin/claude-inte
 run install -m 755 "$SCRIPT_DIR/bin/coding-agents-kit-ctl" "$PREFIX/bin/coding-agents-kit-ctl"
 
 info "Installing plugin..."
-run install -m 644 "$SCRIPT_DIR/share/libcoding_agent_plugin.dylib" "$PREFIX/share/libcoding_agent_plugin.dylib"
+run install -m 644 "$SCRIPT_DIR/share/libcoding_agent.dylib" "$PREFIX/share/libcoding_agent.dylib"
 
 info "Installing configuration..."
 run install -m 644 "$SCRIPT_DIR/config/falco.yaml" "$PREFIX/config/falco.yaml"
@@ -178,7 +178,7 @@ echo ""
 echo "  Install prefix:  $PREFIX"
 echo "  Falco binary:    $PREFIX/bin/falco"
 echo "  Interceptor:     $PREFIX/bin/claude-interceptor"
-echo "  Plugin:          $PREFIX/share/libcoding_agent_plugin.dylib"
+echo "  Plugin:          $PREFIX/share/libcoding_agent.dylib"
 echo "  Config:          $PREFIX/config/"
 echo "  Rules:           $PREFIX/rules/"
 echo "  User rules:      $PREFIX/rules/user/ (add custom rules here)"

--- a/installers/macos/package.sh
+++ b/installers/macos/package.sh
@@ -71,10 +71,10 @@ if [[ "$ARCH" == "universal" ]]; then
         echo "  lipo: $bin"
         lipo -create "$ARM_DIR/$bin" "$X86_DIR/$bin" -output "$BUILD_DIR/$bin"
     done
-    echo "  lipo: share/libcoding_agent_plugin.dylib"
-    lipo -create "$ARM_DIR/share/libcoding_agent_plugin.dylib" \
-                 "$X86_DIR/share/libcoding_agent_plugin.dylib" \
-                 -output "$BUILD_DIR/share/libcoding_agent_plugin.dylib"
+    echo "  lipo: share/libcoding_agent.dylib"
+    lipo -create "$ARM_DIR/share/libcoding_agent.dylib" \
+                 "$X86_DIR/share/libcoding_agent.dylib" \
+                 -output "$BUILD_DIR/share/libcoding_agent.dylib"
 
     # Create tar.gz.
     echo "Creating tar.gz..."
@@ -135,14 +135,14 @@ esac
 if [[ "$ARCH" != "$HOST_ARCH" ]]; then
     CARGO_TARGET_FLAG="--target $RUST_TARGET"
     INTERCEPTOR_BIN="hooks/claude-code/target/$RUST_TARGET/release/claude-interceptor"
-    PLUGIN_LIB="plugins/coding-agent-plugin/target/$RUST_TARGET/release/libcoding_agent_plugin.dylib"
+    PLUGIN_LIB="plugins/coding-agent-plugin/target/$RUST_TARGET/release/libcoding_agent.dylib"
     CTL_BIN="tools/coding-agents-kit-ctl/target/$RUST_TARGET/release/coding-agents-kit-ctl"
     # Ensure Rust target is installed.
     rustup target add "$RUST_TARGET" 2>/dev/null || true
 else
     CARGO_TARGET_FLAG=""
     INTERCEPTOR_BIN="hooks/claude-code/target/release/claude-interceptor"
-    PLUGIN_LIB="plugins/coding-agent-plugin/target/release/libcoding_agent_plugin.dylib"
+    PLUGIN_LIB="plugins/coding-agent-plugin/target/release/libcoding_agent.dylib"
     CTL_BIN="tools/coding-agents-kit-ctl/target/release/coding-agents-kit-ctl"
 fi
 
@@ -180,12 +180,12 @@ mkdir -p "$BUILD_DIR"/{bin,share,config,rules/default,rules/user,launchd}
 # Binaries.
 cp "$ROOT_DIR/$INTERCEPTOR_BIN" "$BUILD_DIR/bin/claude-interceptor"
 cp "$ROOT_DIR/$CTL_BIN" "$BUILD_DIR/bin/coding-agents-kit-ctl"
-cp "$ROOT_DIR/$PLUGIN_LIB" "$BUILD_DIR/share/libcoding_agent_plugin.dylib"
+cp "$ROOT_DIR/$PLUGIN_LIB" "$BUILD_DIR/share/libcoding_agent.dylib"
 cp "$FALCO_BIN" "$BUILD_DIR/bin/falco"
 
 # Config files (with .so -> .dylib transform for macOS).
 cp "$ROOT_DIR/configs/falco.yaml" "$BUILD_DIR/config/"
-sed 's/libcoding_agent_plugin\.so/libcoding_agent_plugin.dylib/g' \
+sed 's/libcoding_agent\.so/libcoding_agent.dylib/g' \
     "$ROOT_DIR/configs/falco.coding_agents_plugin.yaml" \
     > "$BUILD_DIR/config/falco.coding_agents_plugin.yaml"
 
@@ -221,7 +221,7 @@ mkdir -p "$PKG_ROOT"/{bin,share,config,rules/default,rules/user,launchd,log}
 cp "$BUILD_DIR/bin/falco" "$PKG_ROOT/bin/"
 cp "$BUILD_DIR/bin/claude-interceptor" "$PKG_ROOT/bin/"
 cp "$BUILD_DIR/bin/coding-agents-kit-ctl" "$PKG_ROOT/bin/"
-cp "$BUILD_DIR/share/libcoding_agent_plugin.dylib" "$PKG_ROOT/share/"
+cp "$BUILD_DIR/share/libcoding_agent.dylib" "$PKG_ROOT/share/"
 cp "$BUILD_DIR/config/falco.yaml" "$PKG_ROOT/config/"
 cp "$BUILD_DIR/config/falco.coding_agents_plugin.yaml" "$PKG_ROOT/config/"
 cp "$BUILD_DIR/rules/default/coding_agents_rules.yaml" "$PKG_ROOT/rules/default/"

--- a/plugins/coding-agent-plugin/Cargo.toml
+++ b/plugins/coding-agent-plugin/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [lib]
-name = "coding_agent_plugin"
+name = "coding_agent"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/plugins/coding-agent-plugin/README.md
+++ b/plugins/coding-agent-plugin/README.md
@@ -12,7 +12,7 @@ Requires latest stable Rust (the `falco_plugin` SDK tracks latest stable as MSRV
 cargo build --release
 ```
 
-Output: `target/release/libcoding_agent_plugin.so` (Linux) / `.dylib` (macOS)
+Output: `target/release/libcoding_agent.so` (Linux) / `.dylib` (macOS)
 
 ## How It Works
 

--- a/tests/test_e2e.sh
+++ b/tests/test_e2e.sh
@@ -12,7 +12,7 @@ case "$(uname -s)" in
     Darwin) PLUGIN_EXT="dylib" ;;
     *)      PLUGIN_EXT="so" ;;
 esac
-PLUGIN_LIB="${ROOT_DIR}/plugins/coding-agent-plugin/target/release/libcoding_agent_plugin.${PLUGIN_EXT}"
+PLUGIN_LIB="${ROOT_DIR}/plugins/coding-agent-plugin/target/release/libcoding_agent.${PLUGIN_EXT}"
 # Use build/ for temp files to avoid /tmp restrictions on some platforms.
 E2E_DIR="${ROOT_DIR}/build/e2e-$$"
 mkdir -p "$E2E_DIR"


### PR DESCRIPTION
## Summary

Renames the `[lib]` name in `Cargo.toml` from `coding_agent_plugin` to `coding_agent`.

This changes the built artifact from:
- `libcoding_agent_plugin.dylib` (macOS) / `libcoding_agent_plugin.so` (Linux)

to:
- `libcoding_agent.dylib` (macOS) / `libcoding_agent.so` (Linux)

## Why

`plugin_config::get_filepath("coding_agent")` in the Sysdig agent resolves to `{rootdir}/plugins/libcoding_agent.{dylib,so}`. Without this rename the plugin cannot be loaded via the standard registration path and requires a hardcoded `set_library_path()` override.

This is **Decision D3 (mandatory)** from the macOS agent deployment plan, and a prerequisite for the macOS `.pkg` installer to include and load the plugin automatically.

## Test plan
- [ ] `cargo build --release` produces `libcoding_agent.dylib` (not `libcoding_agent_plugin.dylib`)
- [ ] Agent loads plugin successfully from `{rootdir}/plugins/libcoding_agent.dylib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)