### PR TITLE
fix(macos): pkg install lifecycle, ctl enable, install.sh idempotency, dark-mode UI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,6 +168,8 @@ jobs:
         include:
           - arch: aarch64
             runner: macos-latest
+          - arch: x86_64
+            runner: macos-15-intel
     steps:
       - uses: actions/checkout@v4
 
@@ -215,3 +217,9 @@ jobs:
 
       - name: Run e2e tests
         run: make test-e2e
+
+      - name: Build .pkg
+        run: make macos-${{ matrix.arch }}
+
+      - name: Run installed-service smoke test
+        run: bash tests/test_installed_service_macos.sh

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,13 @@ linux-aarch64:
 	bash installers/linux/package.sh --target aarch64
 
 ## Build macOS package for the native architecture
-macos: macos-aarch64
+macos: macos-$(subst arm64,aarch64,$(ARCH))
 
 ## Build macOS package for Apple Silicon
 macos-aarch64:
 	bash installers/macos/package.sh --target aarch64
 
-## Build macOS package for Intel (must run on Intel Mac)
+## Build macOS package for Intel (native on Intel, or via Rosetta cross-compile on Apple Silicon)
 macos-x86_64:
 	bash installers/macos/package.sh --target x86_64
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ The macOS Installer wizard guides you through the setup. Once complete, the serv
 
 > [!NOTE]
 > Since the binaries are not code-signed, macOS Gatekeeper may block them on first run.
-> Go to **System Settings > Privacy & Security** and allow the blocked binary, or run:
+> Go to **System Settings > Privacy & Security** and allow the blocked binary, or clear the quarantine attribute from the whole install tree (executables in `bin/` and the plugin library in `share/` can both be flagged):
 > ```bash
-> xattr -dr com.apple.quarantine ~/.coding-agents-kit/bin/*
+> xattr -dr com.apple.quarantine ~/.coding-agents-kit
 > ```
 
 ### Linux
@@ -268,8 +268,9 @@ brew install cmake openssl@3
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # Build
+make macos              # Native architecture of the host
 make macos-aarch64      # Apple Silicon
-make macos-x86_64       # Intel (must build on matching hardware or via Rosetta)
+make macos-x86_64       # Intel (native on Intel, or Rosetta cross-compile on Apple Silicon)
 make macos-universal    # Universal binary (requires Rosetta + x86_64 Homebrew)
 ```
 

--- a/README.md
+++ b/README.md
@@ -274,18 +274,18 @@ make macos-x86_64       # Intel (native on Intel, or Rosetta cross-compile on Ap
 make macos-universal    # Universal binary (requires Rosetta + x86_64 Homebrew)
 ```
 
-Output: `build/coding-agents-kit-<version>-darwin-{arch}.{tar.gz,pkg}`
+Output: `build/coding-agents-kit-<version>-darwin-<arch>.{tar.gz,pkg}`
 
 Install the locally-built artifact with either:
 
 ```bash
-open build/coding-agents-kit-0.1.0-darwin-<arch>.pkg           # GUI wizard
+open build/coding-agents-kit-<version>-darwin-<arch>.pkg           # GUI wizard
 # or, non-interactive:
-installer -pkg build/coding-agents-kit-0.1.0-darwin-<arch>.pkg \
+installer -pkg build/coding-agents-kit-<version>-darwin-<arch>.pkg \
           -target CurrentUserHomeDirectory
 # or, from the tarball:
-tar xzf build/coding-agents-kit-0.1.0-darwin-<arch>.tar.gz -C /tmp
-bash /tmp/coding-agents-kit-0.1.0-darwin-<arch>/install.sh
+tar xzf build/coding-agents-kit-<version>-darwin-<arch>.tar.gz -C /tmp
+bash /tmp/coding-agents-kit-<version>-darwin-<arch>/install.sh
 ```
 
 > Falco does not ship pre-built macOS binaries. The first build compiles Falco from source (~5 min). Subsequent builds use the cached binary.

--- a/README.md
+++ b/README.md
@@ -276,6 +276,18 @@ make macos-universal    # Universal binary (requires Rosetta + x86_64 Homebrew)
 
 Output: `build/coding-agents-kit-<version>-darwin-{arch}.{tar.gz,pkg}`
 
+Install the locally-built artifact with either:
+
+```bash
+open build/coding-agents-kit-0.1.0-darwin-<arch>.pkg           # GUI wizard
+# or, non-interactive:
+installer -pkg build/coding-agents-kit-0.1.0-darwin-<arch>.pkg \
+          -target CurrentUserHomeDirectory
+# or, from the tarball:
+tar xzf build/coding-agents-kit-0.1.0-darwin-<arch>.tar.gz -C /tmp
+bash /tmp/coding-agents-kit-0.1.0-darwin-<arch>/install.sh
+```
+
 > Falco does not ship pre-built macOS binaries. The first build compiles Falco from source (~5 min). Subsequent builds use the cached binary.
 
 See [`installers/macos/`](installers/macos/) for details.
@@ -316,9 +328,9 @@ make falco-macos          # Falco binary (macOS only)
 
 ```
 ┌──────────────┐      ┌──────────────┐      ┌────────────────────────────┐
-│ Coding Agent │────▶│ Interceptor  │────▶│     Falco (nodriver)       │
+│ Coding Agent │─────▶│ Interceptor  │─────▶│     Falco (nodriver)       │
 │              │      │   (hook)     │      │  ┌───────────────────────┐ │
-│              │◀────│              │◀────│  │  Plugin (src + extract│ │
+│              │◀─────│              │◀─────│  │  Plugin (src + extract│ │
 │              │      │              │      │  │  + embedded broker)   │ │
 └──────────────┘      └──────────────┘      │  └───────────────────────┘ │
                                             │  Rule Engine + Rules       │

--- a/installers/macos/README.md
+++ b/installers/macos/README.md
@@ -22,8 +22,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 Build a distributable package from the repo root:
 
 ```bash
+make macos              # Native architecture of the host
 make macos-aarch64      # Apple Silicon
-make macos-x86_64       # Intel (must build on matching hardware or via Rosetta)
+make macos-x86_64       # Intel (native on Intel, or Rosetta cross-compile on Apple Silicon)
 make macos-universal    # Universal binary (requires Rosetta + x86_64 Homebrew)
 ```
 
@@ -85,10 +86,10 @@ bash install.sh --dry-run                # Show what would be done
 
 ### Gatekeeper
 
-Since the binaries are not code-signed, macOS Gatekeeper may block them. Go to **System Settings > Privacy & Security** and allow the blocked binary, or run:
+Since the binaries are not code-signed, macOS Gatekeeper may block them (especially when installing from a tarball downloaded via a browser). Go to **System Settings > Privacy & Security** and allow the blocked binary, or clear the quarantine attribute from the entire install tree — both the executables in `bin/` and the plugin library in `share/` can be flagged:
 
 ```bash
-xattr -dr com.apple.quarantine ~/.coding-agents-kit/bin/*
+xattr -dr com.apple.quarantine ~/.coding-agents-kit
 ```
 
 ## Uninstallation

--- a/installers/macos/README.md
+++ b/installers/macos/README.md
@@ -65,8 +65,8 @@ The macOS Installer wizard guides you through the setup.
 ### From tar.gz
 
 ```bash
-tar xzf coding-agents-kit-<version>-darwin-aarch64.tar.gz
-cd coding-agents-kit-<version>-darwin-aarch64
+tar xzf coding-agents-kit-<version>-darwin-<arch>.tar.gz
+cd coding-agents-kit-<version>-darwin-<arch>
 bash install.sh
 ```
 

--- a/installers/macos/distribution.xml
+++ b/installers/macos/distribution.xml
@@ -4,7 +4,7 @@
     <welcome file="welcome.html"/>
     <conclusion file="conclusion.html"/>
     <domains enable_currentUserHome="true" enable_localSystem="false" enable_anywhere="false"/>
-    <options customize="never" require-scripts="false" hostArchitectures="arm64,x86_64"/>
+    <options customize="never" require-scripts="false" hostArchitectures="@HOST_ARCHS@"/>
     <pkg-ref id="dev.falcosecurity.coding-agents-kit"/>
     <choices-outline>
         <line choice="default">

--- a/installers/macos/install.sh
+++ b/installers/macos/install.sh
@@ -152,6 +152,12 @@ PLIST_FILE="${PLIST_DIR}/dev.falcosecurity.coding-agents-kit.plist"
 
 if ! $DRY_RUN; then
     mkdir -p "$PLIST_DIR"
+    # If an agent from a previous install is loaded, unload it first.
+    # `launchctl load` fails on an already-loaded plist ("already loaded"),
+    # and we need a clean reload to pick up any plist or launcher changes.
+    if [[ -f "$PLIST_FILE" ]]; then
+        launchctl unload "$PLIST_FILE" 2>/dev/null || true
+    fi
     # Render plist template with actual prefix and HOME.
     sed -e "s|@PREFIX@|${PREFIX}|g" -e "s|@HOME@|${HOME}|g" \
         "$SCRIPT_DIR/launchd/dev.falcosecurity.coding-agents-kit.plist" \
@@ -164,6 +170,7 @@ if ! $DRY_RUN; then
     # Load the service.
     launchctl load "$PLIST_FILE"
 else
+    echo "  [DRY-RUN] launchctl unload $PLIST_FILE (if loaded)"
     echo "  [DRY-RUN] sed → $PLIST_FILE"
     echo "  [DRY-RUN] sed → $PREFIX/bin/coding-agents-kit-launcher.sh"
     echo "  [DRY-RUN] launchctl load $PLIST_FILE"

--- a/installers/macos/install.sh
+++ b/installers/macos/install.sh
@@ -62,16 +62,23 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
 fi
 
 # Verify architecture matches the package.
+# `file` reports all slices for universal binaries, e.g.
+#   "Mach-O universal binary ... [arm64:...] [x86_64:...]"
+# so we collect every arch and accept the package as long as the host arch is
+# one of them. Without this, universal tarballs would be rejected on Intel
+# Macs (the first arch reported by `file` is arm64).
 CURRENT_ARCH="$(uname -m)"
-PACKAGE_ARCH="$(file "$SCRIPT_DIR/bin/falco" 2>/dev/null | grep -oE 'arm64|x86_64' | head -1 || true)"
-if [[ -n "$PACKAGE_ARCH" && "$CURRENT_ARCH" != "$PACKAGE_ARCH" ]]; then
-    # Normalize: arm64 == aarch64 for comparison purposes.
-    NORM_CURRENT="$CURRENT_ARCH"
-    NORM_PACKAGE="$PACKAGE_ARCH"
-    [[ "$NORM_CURRENT" == "arm64" ]] && NORM_CURRENT="aarch64"
-    [[ "$NORM_PACKAGE" == "arm64" ]] && NORM_PACKAGE="aarch64"
-    if [[ "$NORM_CURRENT" != "$NORM_PACKAGE" ]]; then
-        err "Architecture mismatch: package is for $PACKAGE_ARCH but this machine is $CURRENT_ARCH."
+[[ "$CURRENT_ARCH" == "arm64" ]] && CURRENT_ARCH="aarch64"
+PACKAGE_ARCHS="$(file "$SCRIPT_DIR/bin/falco" 2>/dev/null | grep -oE 'arm64|x86_64' | sort -u | tr '\n' ' ' || true)"
+# Normalize arm64 → aarch64 in the arch list.
+PACKAGE_ARCHS="${PACKAGE_ARCHS//arm64/aarch64}"
+if [[ -n "$PACKAGE_ARCHS" ]]; then
+    MATCH=false
+    for a in $PACKAGE_ARCHS; do
+        [[ "$a" == "$CURRENT_ARCH" ]] && MATCH=true && break
+    done
+    if ! $MATCH; then
+        err "Architecture mismatch: package is for ${PACKAGE_ARCHS% } but this machine is $CURRENT_ARCH."
     fi
 fi
 

--- a/installers/macos/install.sh
+++ b/installers/macos/install.sh
@@ -79,6 +79,7 @@ fi
 for f in bin/falco bin/claude-interceptor bin/coding-agents-kit-ctl \
          share/libcoding_agent.dylib \
          config/falco.yaml config/falco.coding_agents_plugin.yaml \
+         rules/default/coding_agents_rules.yaml \
          rules/seen.yaml launchd/dev.falcosecurity.coding-agents-kit.plist \
          launchd/coding-agents-kit-launcher.sh; do
     [[ -f "$SCRIPT_DIR/$f" ]] || err "Missing package file: $f (are you running from the extracted package?)"

--- a/installers/macos/package.sh
+++ b/installers/macos/package.sh
@@ -133,18 +133,22 @@ case "$ARCH" in
 esac
 
 # Set up cross-compilation if target != host.
+# The repository is a Cargo workspace, so every crate builds into a shared
+# `<workspace_root>/target/` regardless of which member directory cargo was
+# invoked from. Do not use per-crate `hooks/.../target/` paths here — they
+# only exist as leftovers from pre-workspace builds on developer machines.
 if [[ "$ARCH" != "$HOST_ARCH" ]]; then
     CARGO_TARGET_FLAG="--target $RUST_TARGET"
-    INTERCEPTOR_BIN="hooks/claude-code/target/$RUST_TARGET/release/claude-interceptor"
-    PLUGIN_LIB="plugins/coding-agent-plugin/target/$RUST_TARGET/release/libcoding_agent.dylib"
-    CTL_BIN="tools/coding-agents-kit-ctl/target/$RUST_TARGET/release/coding-agents-kit-ctl"
+    INTERCEPTOR_BIN="target/$RUST_TARGET/release/claude-interceptor"
+    PLUGIN_LIB="target/$RUST_TARGET/release/libcoding_agent.dylib"
+    CTL_BIN="target/$RUST_TARGET/release/coding-agents-kit-ctl"
     # Ensure Rust target is installed.
     rustup target add "$RUST_TARGET" 2>/dev/null || true
 else
     CARGO_TARGET_FLAG=""
-    INTERCEPTOR_BIN="hooks/claude-code/target/release/claude-interceptor"
-    PLUGIN_LIB="plugins/coding-agent-plugin/target/release/libcoding_agent.dylib"
-    CTL_BIN="tools/coding-agents-kit-ctl/target/release/coding-agents-kit-ctl"
+    INTERCEPTOR_BIN="target/release/claude-interceptor"
+    PLUGIN_LIB="target/release/libcoding_agent.dylib"
+    CTL_BIN="target/release/coding-agents-kit-ctl"
 fi
 
 PACKAGE_NAME="coding-agents-kit-${VERSION}-darwin-${ARCH}"

--- a/installers/macos/package.sh
+++ b/installers/macos/package.sh
@@ -104,7 +104,8 @@ if [[ "$ARCH" == "universal" ]]; then
     mkdir -p "$PKG_RESOURCES"
     cp "$SCRIPT_DIR/pkg-resources/welcome.html" "$PKG_RESOURCES/"
     cp "$SCRIPT_DIR/pkg-resources/conclusion.html" "$PKG_RESOURCES/"
-    sed "s/@VERSION@/$VERSION/g" "$SCRIPT_DIR/distribution.xml" > "$PKG_DIR/distribution.xml"
+    sed -e "s/@VERSION@/$VERSION/g" -e "s/@HOST_ARCHS@/arm64,x86_64/g" \
+        "$SCRIPT_DIR/distribution.xml" > "$PKG_DIR/distribution.xml"
     productbuild --distribution "$PKG_DIR/distribution.xml" --package-path "$PKG_DIR" \
         --resources "$PKG_RESOURCES" "$PRODUCT_PKG" > /dev/null
     rm -rf "$PKG_DIR"
@@ -256,8 +257,18 @@ cp "$SCRIPT_DIR/pkg-resources/welcome.html" "$PKG_RESOURCES/"
 cp "$SCRIPT_DIR/pkg-resources/conclusion.html" "$PKG_RESOURCES/"
 
 # Distribution XML (enables user-home-directory installation).
-sed "s/@VERSION@/$VERSION/g" "$SCRIPT_DIR/distribution.xml" \
-    > "$PKG_DIR/distribution.xml"
+# `hostArchitectures` is narrowed to the pkg's actual arch so that
+# double-clicking a single-arch pkg on the wrong host fails fast in the
+# Installer wizard ("The installer cannot install this software on this
+# computer") rather than succeeding and leaving a Falco binary that Mach-O
+# refuses to exec ("Bad CPU type in executable") at first launch.
+case "$ARCH" in
+    aarch64) HOST_ARCHS="arm64" ;;
+    x86_64)  HOST_ARCHS="x86_64" ;;
+    *)       HOST_ARCHS="arm64,x86_64" ;;
+esac
+sed -e "s/@VERSION@/$VERSION/g" -e "s/@HOST_ARCHS@/$HOST_ARCHS/g" \
+    "$SCRIPT_DIR/distribution.xml" > "$PKG_DIR/distribution.xml"
 
 # Build product archive (the final .pkg with installer wizard).
 productbuild --distribution "$PKG_DIR/distribution.xml" \

--- a/installers/macos/pkg-resources/conclusion.html
+++ b/installers/macos/pkg-resources/conclusion.html
@@ -1,13 +1,54 @@
 <html>
-<body style="font-family: -apple-system, Helvetica, Arial, sans-serif; font-size: 13px;">
+<head>
+<style>
+:root {
+    color-scheme: light dark;
+    --text: #000;
+    --muted: #555;
+    --code-bg: #f0f0f0;
+    --code-fg: #1a1a1a;
+    --code-border: #dcdcdc;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text: #eaeaea;
+        --muted: #a8a8a8;
+        --code-bg: #2a2a2a;
+        --code-fg: #f2f2f2;
+        --code-border: #3d3d3d;
+    }
+}
+body {
+    font-family: -apple-system, Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    color: var(--text);
+}
+pre, code {
+    color: var(--code-fg);
+    background: var(--code-bg);
+}
+pre {
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid var(--code-border);
+    white-space: pre-wrap;
+}
+code {
+    padding: 1px 4px;
+    border-radius: 3px;
+}
+.tip { margin-top: 16px; color: var(--muted); }
+</style>
+</head>
+<body>
 <h2>Installation Complete</h2>
 <p>coding-agents-kit has been installed to <code>~/.coding-agents-kit/</code>.</p>
 <p><b>Verify the installation:</b></p>
-<pre style="background: #f0f0f0; padding: 8px; border-radius: 4px;">~/.coding-agents-kit/bin/coding-agents-kit-ctl status
+<pre>~/.coding-agents-kit/bin/coding-agents-kit-ctl status
 ~/.coding-agents-kit/bin/coding-agents-kit-ctl hook status</pre>
 <p><b>To uninstall:</b></p>
-<pre style="background: #f0f0f0; padding: 8px; border-radius: 4px;">~/.coding-agents-kit/bin/coding-agents-kit-ctl uninstall</pre>
-<p style="margin-top: 16px; color: #666;"><b>Tip:</b> To use <code>coding-agents-kit-ctl</code> without the full path, add this to your shell profile (<code>~/.zshrc</code> or <code>~/.bashrc</code>):</p>
-<pre style="background: #f0f0f0; padding: 8px; border-radius: 4px;">export PATH="$HOME/.coding-agents-kit/bin:$PATH"</pre>
+<pre>~/.coding-agents-kit/bin/coding-agents-kit-ctl uninstall</pre>
+<p class="tip"><b>Tip:</b> To use <code>coding-agents-kit-ctl</code> without the full path, add this to your shell profile (<code>~/.zshrc</code> or <code>~/.bashrc</code>):</p>
+<pre>export PATH="$HOME/.coding-agents-kit/bin:$PATH"</pre>
 </body>
 </html>

--- a/installers/macos/pkg-resources/welcome.html
+++ b/installers/macos/pkg-resources/welcome.html
@@ -1,5 +1,39 @@
 <html>
-<body style="font-family: -apple-system, Helvetica, Arial, sans-serif; font-size: 13px;">
+<head>
+<style>
+:root {
+    color-scheme: light dark;
+    --text: #000;
+    --code-bg: #f0f0f0;
+    --code-fg: #1a1a1a;
+    --code-border: #dcdcdc;
+    --link: #0066cc;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text: #eaeaea;
+        --code-bg: #2a2a2a;
+        --code-fg: #f2f2f2;
+        --code-border: #3d3d3d;
+        --link: #66b3ff;
+    }
+}
+body {
+    font-family: -apple-system, Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    color: var(--text);
+}
+a { color: var(--link); }
+code {
+    background: var(--code-bg);
+    color: var(--code-fg);
+    border: 1px solid var(--code-border);
+    padding: 1px 4px;
+    border-radius: 3px;
+}
+</style>
+</head>
+<body>
 <h2>coding-agents-kit</h2>
 <p>Runtime Security for AI Coding Agents with <a href="https://falco.org">Falco</a>.</p>
 <p>This installer will:</p>

--- a/installers/macos/pkg-scripts/postinstall
+++ b/installers/macos/pkg-scripts/postinstall
@@ -47,24 +47,36 @@ fi
 # ---------------------------------------------------------------------------
 #
 # Postinstall runs either:
-#   - as root, when the user invokes `installer` via sudo or authenticates in
-#     the GUI Installer for a system-scoped component; OR
+#   - as root, when the user invokes `sudo installer -pkg …` or authenticates
+#     in the GUI Installer for a system-scoped component; OR
 #   - as the installing user, when the pkg is user-domain (our case, via
 #     `enable_currentUserHome="true"`) and the GUI Installer.app or
 #     `installer -target CurrentUserHomeDirectory` runs the scripts without
 #     elevation.
 #
-# Only drop privileges via `su` when we are actually root; otherwise run
-# `launchctl` directly so the agent is loaded into the current user's session.
-# Running `su $OWNER` as a non-root user fails (password prompt) and was
-# silently swallowed, leaving the agent unloaded until the next login.
+# In the elevated case we can't just call `launchctl load` from root — the
+# agent would land in the `system`/`background` domain, not the user's
+# `gui/$UID` session where the GUI clients expect it. `launchctl asuser $UID`
+# explicitly crosses into the user's launchd session and is the
+# Apple-documented way to load a LaunchAgent from a root context.
+#
+# Errors are NOT redirected to /dev/null so Installer.app surfaces them in
+# "Show Details"; `|| true` keeps the overall install from failing if the
+# agent can't load for an unrelated reason (the user can retry with ctl).
 
 OWNER=$(stat -f '%Su' "$USER_HOME")
+OWNER_UID=$(id -u "$OWNER" 2>/dev/null || echo "")
 
-if [[ "$(id -u)" -eq 0 && -n "$OWNER" && "$OWNER" != "root" ]]; then
-    su "$OWNER" -c "launchctl load '$PLIST_FILE'" 2>/dev/null || true
+if [[ "$(id -u)" -eq 0 && -n "$OWNER_UID" && "$OWNER" != "root" ]]; then
+    # When installer runs as root, PackageKit extracts the payload with root
+    # ownership even for user-domain targets. Reassign the install tree and
+    # rendered plist to the installing user so they can manage the service
+    # and uninstall without sudo.
+    chown -R "$OWNER" "$PREFIX" || true
+    chown "$OWNER" "$PLIST_FILE" || true
+    launchctl asuser "$OWNER_UID" /bin/launchctl load "$PLIST_FILE" || true
 else
-    launchctl load "$PLIST_FILE" 2>/dev/null || true
+    launchctl load "$PLIST_FILE" || true
 fi
 
 exit 0

--- a/installers/macos/pkg-scripts/postinstall
+++ b/installers/macos/pkg-scripts/postinstall
@@ -45,12 +45,23 @@ fi
 # ---------------------------------------------------------------------------
 # Start service
 # ---------------------------------------------------------------------------
+#
+# Postinstall runs either:
+#   - as root, when the user invokes `installer` via sudo or authenticates in
+#     the GUI Installer for a system-scoped component; OR
+#   - as the installing user, when the pkg is user-domain (our case, via
+#     `enable_currentUserHome="true"`) and the GUI Installer.app or
+#     `installer -target CurrentUserHomeDirectory` runs the scripts without
+#     elevation.
+#
+# Only drop privileges via `su` when we are actually root; otherwise run
+# `launchctl` directly so the agent is loaded into the current user's session.
+# Running `su $OWNER` as a non-root user fails (password prompt) and was
+# silently swallowed, leaving the agent unloaded until the next login.
 
-# Get the actual username from the install location path.
 OWNER=$(stat -f '%Su' "$USER_HOME")
 
-# Load launchd agent as the installing user (postinstall runs as root).
-if [[ -n "$OWNER" && "$OWNER" != "root" ]]; then
+if [[ "$(id -u)" -eq 0 && -n "$OWNER" && "$OWNER" != "root" ]]; then
     su "$OWNER" -c "launchctl load '$PLIST_FILE'" 2>/dev/null || true
 else
     launchctl load "$PLIST_FILE" 2>/dev/null || true

--- a/installers/macos/pkg-scripts/preinstall
+++ b/installers/macos/pkg-scripts/preinstall
@@ -9,18 +9,19 @@ INSTALL_LOCATION="$2"
 PREFIX="${INSTALL_LOCATION}/.coding-agents-kit"
 USER_HOME="${INSTALL_LOCATION}"
 PLIST_FILE="${USER_HOME}/Library/LaunchAgents/dev.falcosecurity.coding-agents-kit.plist"
-OWNER=$(stat -f '%Su' "$USER_HOME" 2>/dev/null)
+OWNER=$(stat -f '%Su' "$USER_HOME" 2>/dev/null || echo "")
+OWNER_UID=$(id -u "$OWNER" 2>/dev/null || echo "")
 
 # Stop existing service if running. See postinstall for a description of the
-# root-vs-user invocation cases — `su` only works as root, so we only drop
-# privileges when we're actually root. Otherwise run launchctl directly in
-# the current session so the existing agent is genuinely unloaded before the
-# new binaries overwrite it.
+# root-vs-user invocation cases. From root we cross into the user's launchd
+# session via `launchctl asuser` so the unload actually targets the running
+# `gui/$UID` agent, not the root-context `system` domain. Errors are no
+# longer silenced so Installer.app surfaces them in "Show Details".
 if [[ -f "$PLIST_FILE" ]]; then
-    if [[ "$(id -u)" -eq 0 && -n "$OWNER" && "$OWNER" != "root" ]]; then
-        su "$OWNER" -c "launchctl unload '$PLIST_FILE'" 2>/dev/null || true
+    if [[ "$(id -u)" -eq 0 && -n "$OWNER_UID" && "$OWNER" != "root" ]]; then
+        launchctl asuser "$OWNER_UID" /bin/launchctl unload "$PLIST_FILE" || true
     else
-        launchctl unload "$PLIST_FILE" 2>/dev/null || true
+        launchctl unload "$PLIST_FILE" || true
     fi
 fi
 

--- a/installers/macos/pkg-scripts/preinstall
+++ b/installers/macos/pkg-scripts/preinstall
@@ -11,9 +11,13 @@ USER_HOME="${INSTALL_LOCATION}"
 PLIST_FILE="${USER_HOME}/Library/LaunchAgents/dev.falcosecurity.coding-agents-kit.plist"
 OWNER=$(stat -f '%Su' "$USER_HOME" 2>/dev/null)
 
-# Stop existing service if running.
+# Stop existing service if running. See postinstall for a description of the
+# root-vs-user invocation cases — `su` only works as root, so we only drop
+# privileges when we're actually root. Otherwise run launchctl directly in
+# the current session so the existing agent is genuinely unloaded before the
+# new binaries overwrite it.
 if [[ -f "$PLIST_FILE" ]]; then
-    if [[ -n "$OWNER" && "$OWNER" != "root" ]]; then
+    if [[ "$(id -u)" -eq 0 && -n "$OWNER" && "$OWNER" != "root" ]]; then
         su "$OWNER" -c "launchctl unload '$PLIST_FILE'" 2>/dev/null || true
     else
         launchctl unload "$PLIST_FILE" 2>/dev/null || true

--- a/tests/test_installed_service_macos.sh
+++ b/tests/test_installed_service_macos.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# test_installed_service_macos.sh — Integration test for the installed
+# coding-agents-kit service on macOS.
+#
+# Drives the .pkg through `installer -pkg` (matching the GUI Installer.app
+# code path), exercises the launchd-managed service end to end, and verifies
+# the documented `coding-agents-kit-ctl` lifecycle leaves a clean system.
+#
+# Usage:
+#   bash tests/test_installed_service_macos.sh [PATH_TO_PKG]
+#
+# If no pkg path is given, the most recent build/coding-agents-kit-*-darwin-*.pkg
+# is used. Run `make macos-<arch>` first.
+#
+# Requires: macOS, no other coding-agents-kit install loaded.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+PKG="${1:-}"
+if [[ -z "$PKG" ]]; then
+    PKG=$(ls -t "$ROOT_DIR"/build/coding-agents-kit-*-darwin-*.pkg 2>/dev/null | head -1 || true)
+fi
+if [[ ! -f "$PKG" ]]; then
+    echo "ERROR: no .pkg found. Pass a path as the first argument, or run \`make macos-<arch>\` first." >&2
+    exit 1
+fi
+
+PREFIX="$HOME/.coding-agents-kit"
+PLIST="$HOME/Library/LaunchAgents/dev.falcosecurity.coding-agents-kit.plist"
+LABEL="dev.falcosecurity.coding-agents-kit"
+HOOK="$PREFIX/bin/claude-interceptor"
+CTL="$PREFIX/bin/coding-agents-kit-ctl"
+SOCK="$PREFIX/run/broker.sock"
+PASS=0
+FAIL=0
+
+bool() { [[ "$1" -eq 0 ]] && echo 1 || echo 0; }
+
+assert() {
+    local name="$1"; local val="$2"
+    if [[ "$val" == "1" ]]; then
+        echo "  PASS: $name"
+        PASS=$((PASS+1))
+    else
+        echo "  FAIL: $name"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+cleanup() {
+    if [[ -x "$CTL" ]]; then
+        "$CTL" uninstall >/dev/null 2>&1 || true
+    fi
+    launchctl unload "$PLIST" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+run_hook() {
+    CODING_AGENTS_KIT_TIMEOUT_MS=8000 \
+        printf '%s' "$1" | "$HOOK"
+}
+
+wait_for_socket() {
+    local timeout=${1:-10}
+    local i=0
+    while (( i < timeout * 4 )); do
+        [[ -S "$SOCK" ]] && return 0
+        sleep 0.25
+        i=$((i+1))
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Pre-test: ensure clean slate
+# ---------------------------------------------------------------------------
+
+echo "=== Setup ==="
+launchctl unload "$PLIST" 2>/dev/null || true
+rm -rf "$PREFIX" "$PLIST"
+echo "  Slate clean: $PREFIX, $PLIST"
+
+# ---------------------------------------------------------------------------
+# Install
+# ---------------------------------------------------------------------------
+
+echo
+echo "=== Install ==="
+installer -pkg "$PKG" -target CurrentUserHomeDirectory >/dev/null
+echo "  Installed: $(basename "$PKG")"
+
+if ! wait_for_socket 15; then
+    echo "FATAL: broker socket never appeared after install"
+    [[ -f "$PREFIX/log/falco.err" ]] && { echo "--- falco.err ---"; tail -40 "$PREFIX/log/falco.err"; }
+    [[ -f "$PREFIX/log/falco.log" ]] && { echo "--- falco.log ---"; tail -40 "$PREFIX/log/falco.log"; }
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+echo
+echo "=== Preflight ==="
+assert "binary: falco"                     "$( [[ -x "$PREFIX/bin/falco" ]] && echo 1 || echo 0 )"
+assert "binary: claude-interceptor"        "$( [[ -x "$PREFIX/bin/claude-interceptor" ]] && echo 1 || echo 0 )"
+assert "binary: coding-agents-kit-ctl"     "$( [[ -x "$PREFIX/bin/coding-agents-kit-ctl" ]] && echo 1 || echo 0 )"
+assert "plugin: libcoding_agent.dylib"     "$( [[ -f "$PREFIX/share/libcoding_agent.dylib" ]] && echo 1 || echo 0 )"
+assert "config: falco.yaml"                "$( [[ -f "$PREFIX/config/falco.yaml" ]] && echo 1 || echo 0 )"
+assert "rules: default ruleset"            "$( [[ -f "$PREFIX/rules/default/coding_agents_rules.yaml" ]] && echo 1 || echo 0 )"
+assert "rules: seen.yaml"                  "$( [[ -f "$PREFIX/rules/seen.yaml" ]] && echo 1 || echo 0 )"
+assert "launchd plist installed"           "$( [[ -f "$PLIST" ]] && echo 1 || echo 0 )"
+assert "launchd agent registered"          "$( launchctl list "$LABEL" >/dev/null 2>&1 && echo 1 || echo 0 )"
+assert "broker socket up"                  "$( [[ -S "$SOCK" ]] && echo 1 || echo 0 )"
+
+# ---------------------------------------------------------------------------
+# Interceptor pipeline
+# ---------------------------------------------------------------------------
+
+echo
+echo "=== Interceptor pipeline ==="
+OUT=$(run_hook '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo hello"},"session_id":"smoke","cwd":"/tmp","tool_use_id":"smoke_allow"}')
+assert "interceptor returns a verdict"     "$( [[ "$OUT" == *'"permissionDecision"'* ]] && echo 1 || echo 0 )"
+assert "safe Bash → allow"                 "$( [[ "$OUT" == *'"permissionDecision":"allow"'* ]] && echo 1 || echo 0 )"
+
+OUT=$(run_hook '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"/tmp/readme.txt"},"session_id":"smoke","cwd":"/tmp","tool_use_id":"smoke_read"}')
+assert "Read /tmp/* → allow"               "$( [[ "$OUT" == *'"permissionDecision":"allow"'* ]] && echo 1 || echo 0 )"
+
+# Sensitive-path deny via basename-match on a .env file. Using a basename
+# rather than a prefix like /etc/ sidesteps the macOS /etc → /private/etc
+# canonicalisation that would make a prefix rule miss.
+OUT=$(run_hook '{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/tmp/smoke/.env","content":"x"},"session_id":"smoke","cwd":"/tmp","tool_use_id":"smoke_deny"}')
+assert "Write .env → deny (default rule)"  "$( [[ "$OUT" == *'"permissionDecision":"deny"'* ]] && echo 1 || echo 0 )"
+
+# ---------------------------------------------------------------------------
+# ctl commands
+# ---------------------------------------------------------------------------
+
+echo
+echo "=== ctl ==="
+"$CTL" status >/dev/null 2>&1
+assert "ctl status exits 0"                "$( bool $? )"
+
+OUT=$("$CTL" mode 2>/dev/null)
+assert "ctl mode reports enforcement"      "$( [[ "$OUT" == "enforcement" ]] && echo 1 || echo 0 )"
+
+"$CTL" health >/dev/null 2>&1
+assert "ctl health exits 0"                "$( bool $? )"
+
+# Regression: disable → enable used to fail with "Load failed: 5: I/O error".
+"$CTL" disable >/dev/null 2>&1
+sleep 1
+"$CTL" enable  >/dev/null 2>&1
+assert "ctl disable→enable round-trip"     "$( bool $? )"
+wait_for_socket 10
+assert "broker socket back after enable"   "$( [[ -S "$SOCK" ]] && echo 1 || echo 0 )"
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+
+echo
+echo "=== Uninstall ==="
+"$CTL" uninstall >/dev/null 2>&1
+sleep 1
+assert "prefix removed"                    "$( [[ ! -d "$PREFIX" ]] && echo 1 || echo 0 )"
+assert "launchd plist removed"             "$( [[ ! -f "$PLIST" ]] && echo 1 || echo 0 )"
+assert "launchd agent unregistered"        "$( launchctl list "$LABEL" >/dev/null 2>&1 && echo 0 || echo 1 )"
+
+# Already uninstalled — disarm the trap so it doesn't double-uninstall.
+trap - EXIT
+
+echo
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "================================"
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tests/test_installed_service_macos.sh
+++ b/tests/test_installed_service_macos.sh
@@ -8,6 +8,19 @@
 # code path), exercises the launchd-managed service end to end, and verifies
 # the documented `coding-agents-kit-ctl` lifecycle leaves a clean system.
 #
+# Only the non-elevated install path is exercised here. Our pkg declares
+# `enable_currentUserHome="true"` / `enable_localSystem="false"`, so:
+#
+#   - GUI Installer.app runs the pre/postinstall scripts as the installing
+#     user, not root. No admin-authentication step triggers.
+#   - `sudo installer -pkg …` is rejected by macOS with "The package is
+#     attempting to install content to the system volume."
+#
+# That means the `id -u == 0` branch in our scripts is unreachable via any
+# documented install flow for this pkg. It's defensive code should the pkg
+# configuration ever grow a system-scoped component; we rely on code review
+# rather than CI for that branch.
+#
 # Usage:
 #   bash tests/test_installed_service_macos.sh [PATH_TO_PKG]
 #
@@ -90,7 +103,10 @@ echo "  Slate clean: $PREFIX, $PLIST"
 
 echo
 echo "=== Install ==="
-installer -pkg "$PKG" -target CurrentUserHomeDirectory >/dev/null
+if ! installer -pkg "$PKG" -target CurrentUserHomeDirectory; then
+    echo "FATAL: \`installer -pkg\` failed (see installer output above)" >&2
+    exit 1
+fi
 echo "  Installed: $(basename "$PKG")"
 
 if ! wait_for_socket 15; then
@@ -115,6 +131,7 @@ assert "rules: default ruleset"            "$( [[ -f "$PREFIX/rules/default/codi
 assert "rules: seen.yaml"                  "$( [[ -f "$PREFIX/rules/seen.yaml" ]] && echo 1 || echo 0 )"
 assert "launchd plist installed"           "$( [[ -f "$PLIST" ]] && echo 1 || echo 0 )"
 assert "launchd agent registered"          "$( launchctl list "$LABEL" >/dev/null 2>&1 && echo 1 || echo 0 )"
+assert "agent loaded in gui/\$UID"         "$( launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1 && echo 1 || echo 0 )"
 assert "broker socket up"                  "$( [[ -S "$SOCK" ]] && echo 1 || echo 0 )"
 
 # ---------------------------------------------------------------------------
@@ -151,13 +168,14 @@ assert "ctl mode reports enforcement"      "$( [[ "$OUT" == "enforcement" ]] && 
 "$CTL" health >/dev/null 2>&1
 assert "ctl health exits 0"                "$( bool $? )"
 
-# Regression: disable → enable used to fail with "Load failed: 5: I/O error".
+# Regression: disable → start used to fail with "Load failed: 5: I/O error"
+# before `start`/`enable` learned to pass `-w` to launchctl load.
 "$CTL" disable >/dev/null 2>&1
 sleep 1
-"$CTL" enable  >/dev/null 2>&1
-assert "ctl disable→enable round-trip"     "$( bool $? )"
+"$CTL" start   >/dev/null 2>&1
+assert "ctl disable→start round-trip"      "$( bool $? )"
 wait_for_socket 10
-assert "broker socket back after enable"   "$( [[ -S "$SOCK" ]] && echo 1 || echo 0 )"
+assert "broker socket back after start"    "$( [[ -S "$SOCK" ]] && echo 1 || echo 0 )"
 
 # ---------------------------------------------------------------------------
 # Uninstall

--- a/tools/coding-agents-kit-ctl/src/main.rs
+++ b/tools/coding-agents-kit-ctl/src/main.rs
@@ -420,8 +420,11 @@ fn service_start() {
         println!("Service already running.");
         return;
     }
+    // `-w` clears any persistent "disabled" override left behind by a prior
+    // `disable` (which uses `launchctl unload -w`). Both `start` and `enable`
+    // mean "want the agent running now" and must handle the disabled state.
     let ok = Command::new("launchctl")
-        .args(["load", &plist.to_string_lossy()])
+        .args(["load", "-w", &plist.to_string_lossy()])
         .status()
         .map(|s| s.success())
         .unwrap_or(false);

--- a/tools/coding-agents-kit-ctl/src/main.rs
+++ b/tools/coding-agents-kit-ctl/src/main.rs
@@ -466,9 +466,13 @@ fn service_enable() {
     }
     // On macOS, the plist has RunAtLoad=true, so loading it both
     // enables auto-start and starts the service immediately.
+    // `-w` clears any persistent "disabled" override left behind by
+    // `launchctl unload -w` (our `disable` command). Without `-w`,
+    // a previously disabled agent would refuse to load with
+    // "Load failed: 5: Input/output error".
     if !is_service_loaded() {
         let ok = Command::new("launchctl")
-            .args(["load", &plist.to_string_lossy()])
+            .args(["load", "-w", &plist.to_string_lossy()])
             .status()
             .map(|s| s.success())
             .unwrap_or(false);


### PR DESCRIPTION
## Summary

Audit pass over the macOS install paths, ctl behaviour, build defaults, docs, and CI so a fresh user from the `.pkg` ends up with a running, predictable, uninstallable product.

## What changes

- `.pkg` install lifecycle: pre/postinstall scripts now actually start the service when the wizard runs as the user (the previous `su $OWNER` path silently failed and left the agent unloaded until the next login). Welcome and conclusion pages render legibly in dark mode.
- `coding-agents-kit-ctl enable` passes `-w` to `launchctl load`, so the documented `disable → enable` cycle works again.
- `install.sh` (tarball path) is idempotent across reruns, accepts universal binaries on either host arch, and refuses to start when the default ruleset is missing from the package.
- `make macos` tracks the host architecture instead of always selecting aarch64; the `make macos-x86_64` description no longer claims it requires Intel hardware.
- New installed-service smoke test (`tests/test_installed_service_macos.sh`, mirrors the Windows one): drives the built `.pkg` through `installer -pkg`, walks the documented ctl lifecycle and the interceptor pipeline, and asserts uninstall leaves no residue.
- CI: macOS matrix now covers x86_64 alongside aarch64, and runs the smoke test against the freshly built `.pkg` on every PR. 
- Documentation: clearer Gatekeeper guidance (whole tree, not just `bin/`), a "how to install what you just built" snippet for the from-source flow, and macOS docs adopt the `<version>` placeholder convention introduced for Windows so the snippets stay correct as the version moves.