### PR TITLE
fix(macos,ctl,docs): release-validation cleanup

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,18 +40,31 @@ jobs:
           if-no-files-found: error
 
   macos:
-    name: Release (macOS ${{ matrix.arch }})
+    name: Release (macOS universal)
     runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [aarch64]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch head as of 2026-04
+        with:
+          targets: x86_64-apple-darwin
 
-      - name: Install build dependencies
+      - name: Install Rosetta
+        run: sudo softwareupdate --install-rosetta --agree-to-license
+
+      - name: Install arm64 build dependencies
         run: brew install cmake openssl@3
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+
+      - name: Install x86_64 Homebrew at /usr/local
+        env:
+          NONINTERACTIVE: "1"
+        run: |
+          arch -x86_64 /bin/bash -c \
+            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+      - name: Install x86_64 build dependencies
+        run: arch -x86_64 /usr/local/bin/brew install cmake openssl@3
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
 
@@ -61,18 +74,18 @@ jobs:
           path: |
             build/falco-*-darwin-*
             build/falco-src-*
-          key: falco-macos-${{ matrix.arch }}-${{ hashFiles('installers/macos/build-falco.sh', 'installers/macos/falco-macos-http-output.patch') }}
+          key: falco-macos-universal-${{ hashFiles('installers/macos/build-falco.sh', 'installers/macos/falco-macos-http-output.patch') }}
 
       - name: Package
-        run: make macos-${{ matrix.arch }}
+        run: make macos-universal
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: macos-${{ matrix.arch }}
+          name: macos-universal
           path: |
-            build/coding-agents-kit-*-darwin-*.tar.gz
-            build/coding-agents-kit-*-darwin-*.pkg
+            build/coding-agents-kit-*-darwin-universal.tar.gz
+            build/coding-agents-kit-*-darwin-universal.pkg
           if-no-files-found: error
 
   windows:
@@ -152,7 +165,7 @@ jobs:
           files: |
             artifacts/linux-x86_64/*
             artifacts/linux-aarch64/*
-            artifacts/macos-aarch64/*
+            artifacts/macos-universal/*
             artifacts/windows-x64/*
             artifacts/windows-arm64/*
           fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -56,13 +56,20 @@ Switch between modes at any time with `coding-agents-kit-ctl mode <guardrails|mo
 
 ### macOS
 
-Download the `.pkg` installer from the [latest release](https://github.com/leogr/coding-agents-kit/releases/latest) and open it:
+Download the universal `.pkg` installer from the [latest release](https://github.com/leogr/coding-agents-kit/releases/latest) and open it:
 
 ```bash
 open coding-agents-kit-<version>-darwin-universal.pkg
 ```
 
-The macOS Installer wizard guides you through the setup. Once complete, the service starts automatically on login.
+The macOS Installer wizard guides you through the setup. The service starts immediately and on every subsequent login.
+
+To install non-interactively (CI, scripted setup, SSH session):
+
+```bash
+installer -pkg coding-agents-kit-<version>-darwin-universal.pkg \
+          -target CurrentUserHomeDirectory
+```
 
 > [!NOTE]
 > Since the binaries are not code-signed, macOS Gatekeeper may block them on first run.
@@ -160,6 +167,9 @@ coding-agents-kit-ctl start
 
 ```bash
 ~/.coding-agents-kit/bin/coding-agents-kit-ctl uninstall
+
+# Keep your custom rules in rules/user/ for a future reinstall:
+~/.coding-agents-kit/bin/coding-agents-kit-ctl uninstall --keep-user-rules
 ```
 
 **Windows**

--- a/installers/macos/pkg-scripts/postinstall
+++ b/installers/macos/pkg-scripts/postinstall
@@ -9,7 +9,16 @@
 #   $3 = target volume
 #   $4 = root directory for the system
 
-INSTALL_LOCATION="$2"
+if [[ -z "$2" ]] || [[ ! -d "$2" ]]; then
+    echo "postinstall: invalid install location: $2" >&2
+    exit 1
+fi
+
+# Installer passes "$2" with a trailing /. for user-domain installs; strip
+# textually rather than via cd/pwd -P so we keep the conventional path
+# (preserve a symlinked HOME instead of resolving it).
+INSTALL_LOCATION="${2%/.}"
+INSTALL_LOCATION="${INSTALL_LOCATION%/}"
 PREFIX="${INSTALL_LOCATION}/.coding-agents-kit"
 USER_HOME="${INSTALL_LOCATION}"
 

--- a/tools/coding-agents-kit-ctl/src/main.rs
+++ b/tools/coding-agents-kit-ctl/src/main.rs
@@ -346,7 +346,7 @@ fn mode_set(prefix: &PathBuf, mode: &str) {
     print_restart_warning();
     eprintln!();
 
-    service_stop();
+    service_stop(false);
 
     // Re-register the hook before starting back up so the brief restart
     // window stays fail-closed (interceptor → no broker → deny) rather than
@@ -358,7 +358,7 @@ fn mode_set(prefix: &PathBuf, mode: &str) {
         hook_add(prefix);
     }
 
-    service_start();
+    service_start(prefix);
 
     println!();
     println!("Mode set to: {mode}");
@@ -379,6 +379,34 @@ fn warn_hook_still_registered() {
             eprintln!("  Remove the hook manually if needed:");
             eprintln!("    coding-agents-kit-ctl hook remove");
         }
+    }
+}
+
+// systemctl/launchctl return as soon as the supervisor accepts the process,
+// but the plugin binds the broker socket later, after Falco's init_config.
+#[cfg(unix)]
+fn await_broker_ready(prefix: &PathBuf, timeout: std::time::Duration) -> bool {
+    use std::os::unix::net::UnixStream;
+    let socket = prefix.join("run/broker.sock");
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if UnixStream::connect(&socket).is_ok() {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+#[cfg(unix)]
+fn report_start_result(broker_ready: bool) {
+    if broker_ready {
+        println!("Service started.");
+    } else {
+        println!("Service started, but broker socket is not accepting connections yet.");
+        println!("Wait a moment and run `coding-agents-kit-ctl health` to verify.");
     }
 }
 
@@ -403,20 +431,21 @@ fn is_service_running() -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn service_start() {
-    if systemctl(&["start", SERVICE_NAME]) {
-        println!("Service started.");
-    } else {
+fn service_start(prefix: &PathBuf) {
+    if !systemctl(&["start", SERVICE_NAME]) {
         eprintln!("Failed to start service.");
         process::exit(1);
     }
+    report_start_result(await_broker_ready(prefix, std::time::Duration::from_secs(5)));
 }
 
 #[cfg(target_os = "linux")]
-fn service_stop() {
+fn service_stop(warn_hook: bool) {
     if systemctl(&["stop", SERVICE_NAME]) {
         println!("Service stopped.");
-        warn_hook_still_registered();
+        if warn_hook {
+            warn_hook_still_registered();
+        }
     } else {
         eprintln!("Failed to stop service.");
         process::exit(1);
@@ -477,7 +506,7 @@ fn is_service_running() -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn service_start() {
+fn service_start(prefix: &PathBuf) {
     let plist = plist_path();
     if !plist.exists() {
         eprintln!("Plist not found: {}", plist.display());
@@ -496,16 +525,15 @@ fn service_start() {
         .status()
         .map(|s| s.success())
         .unwrap_or(false);
-    if ok {
-        println!("Service started.");
-    } else {
+    if !ok {
         eprintln!("Failed to start service.");
         process::exit(1);
     }
+    report_start_result(await_broker_ready(prefix, std::time::Duration::from_secs(5)));
 }
 
 #[cfg(target_os = "macos")]
-fn service_stop() {
+fn service_stop(warn_hook: bool) {
     if !is_service_loaded() {
         println!("Service not running.");
         return;
@@ -520,7 +548,9 @@ fn service_stop() {
         .unwrap_or(false);
     if ok {
         println!("Service stopped.");
-        warn_hook_still_registered();
+        if warn_hook {
+            warn_hook_still_registered();
+        }
     } else {
         eprintln!("Failed to stop service.");
         process::exit(1);
@@ -632,12 +662,11 @@ fn falco_pids() -> Option<Vec<u32>> {
 }
 
 #[cfg(target_os = "windows")]
-fn service_start() {
+fn service_start(prefix: &PathBuf) {
     if is_falco_running() {
         println!("Service already running.");
         return;
     }
-    let prefix = default_prefix();
     let launcher = prefix.join("bin").join("coding-agents-kit-launcher.ps1");
     if !launcher.exists() {
         eprintln!("Launcher not found: {}", launcher.display());
@@ -690,7 +719,7 @@ fn service_start() {
 }
 
 #[cfg(target_os = "windows")]
-fn service_stop() {
+fn service_stop(warn_hook: bool) {
     let Some(pids) = falco_pids() else {
         println!("Service not running.");
         return;
@@ -714,7 +743,9 @@ fn service_stop() {
     }
 
     println!("Service stopped.");
-    warn_hook_still_registered();
+    if warn_hook {
+        warn_hook_still_registered();
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -859,7 +890,7 @@ fn uninstall(prefix: &PathBuf, keep_user_rules: bool) {
         // below.
         if is_falco_running() {
             println!("Stopping service...");
-            service_stop();
+            service_stop(false);
         }
         // Remove auto-start registry key.
         let _ = Command::new("reg")
@@ -1308,8 +1339,8 @@ fn main() {
         ["hook", "status"] => hook_status(),
         ["mode"] => mode_get(&prefix),
         ["mode", mode] => mode_set(&prefix, mode),
-        ["start"] => service_start(),
-        ["stop"] => service_stop(),
+        ["start"] => service_start(&prefix),
+        ["stop"] => service_stop(true),
         ["enable"] => service_enable(),
         ["disable"] => service_disable(),
         ["status"] => service_status(),


### PR DESCRIPTION
- **postinstall**: strip the trailing `/.` macOS Installer hands user-domain installs as `$2`, so paths in the plist and `ctl status` no longer show `/Users/<user>/./.coding-agents-kit/...`.
- **ctl start**: wait for the broker socket to accept connections before reporting "Service started." Closes the race where `health` (or any tool call) immediately after `start` saw `Connection refused`.
- **ctl mode**: drop the misleading "remove the hook manually" warning printed during the mode-change restart cycle — `mode_set` re-registers the hook itself a moment later.
- **release pipeline (macOS)**: switch from arm64-only to universal `.pkg`, matching what the README has always claimed. Adds Rosetta + x86_64 Homebrew install to the runner so `make macos-universal` can cross-compile the x86_64 Falco slice.