### PR TITLE
chore(github): add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Report a bug encountered while using Prempti
+labels: kind/bug
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks! -->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Prempti version (`premptictl --version`):
+- Falco version (`<prefix>/bin/falco --version`):
+- Coding agent and version (e.g., Claude Code):
+- OS and architecture (e.g., macOS 14.5 arm64, Ubuntu 24.04 x86_64, Windows 11 x64):
+- Install method (Linux tarball / macOS pkg / Windows MSI / built from source):
+- Mode (`guardrails` / `monitor`):

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to the Prempti project
+labels: kind/feature
+
+---
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,73 @@
+<!--  Thanks for sending a pull request! Here are some tips for you:
+1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
+2. Please label this pull request according to what type of issue you are addressing.
+3. Please add a release note!
+4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
+-->
+
+**What type of PR is this?**
+
+> Uncomment one (or more) `/kind <>` lines:
+
+> /kind bug
+
+> /kind cleanup
+
+> /kind design
+
+> /kind documentation
+
+> /kind failing-test
+
+> /kind feature
+
+> /kind release
+
+<!--
+Please remove the leading whitespace before the `/kind <>` you uncommented.
+-->
+
+**Any specific area of the project related to this PR?**
+
+> Uncomment one (or more) `/area <>` lines:
+
+> /area build
+
+> /area CI
+
+> /area ctl
+
+> /area documentation
+
+> /area installer
+
+> /area interceptor
+
+> /area plugin
+
+> /area rules
+
+> /area skills
+
+> /area supervisor
+
+> /area tests
+
+<!--
+Please remove the leading whitespace before the `/area <>` you uncommented.
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+
+<!--
+Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
+-->
+
+Fixes #
+
+**Special notes for your reviewer**:
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,24 +4,9 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'output/**'
-      - 'LICENSE'
-      - '.claude-plugin/**'
-      - 'skills/**'
-      - 'TODOs.md'
+
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'output/**'
-      - 'LICENSE'
-      - '.claude-plugin/**'
-      - 'skills/**'
-      - 'TODOs.md'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

Adds a  PR template and two issue templates (bug report, enhancement request).

The `/area` list is scoped to Prempti's components: `interceptor`, `plugin`, `supervisor`, `ctl`, `rules`, `installer`, `skills`, `tests`, `build`, `CI`, `documentation`. The bug report adds a Prempti-specific environment block (version, OS/arch, install method, mode).

This aligns Prempti's contribution flow with the rest of the org and gives maintainers consistent `kind/*` and `area/*` labels for triage.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**: