### PR TITLE
fix(hooks): set socket timeouts before I/O to avoid macOS EINVAL race

### DIFF
--- a/hooks/claude-code/src/main.rs
+++ b/hooks/claude-code/src/main.rs
@@ -28,7 +28,7 @@ use std::io::{self, BufRead, Read, Write};
 #[cfg(unix)]
 use std::net::Shutdown;
 use std::process;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 // ---------------------------------------------------------------------------
 // Data types
@@ -181,14 +181,6 @@ fn get_timeout() -> Duration {
 // Socket communication
 // ---------------------------------------------------------------------------
 
-/// Compute remaining time from a deadline. Returns Err if expired.
-fn remaining_timeout(start: Instant, timeout: Duration) -> Result<Duration, String> {
-    timeout
-        .checked_sub(start.elapsed())
-        .filter(|d| !d.is_zero())
-        .ok_or_else(|| "broker response timeout".to_string())
-}
-
 /// Translate a `shutdown(Write)` result into the interceptor's String error.
 /// Tolerates the "peer already disconnected" family because a fast broker
 /// can read the newline-terminated request, write its response, and drop
@@ -213,8 +205,6 @@ fn tolerate_disconnected_shutdown(result: io::Result<()>) -> Result<(), String> 
 
 /// Connect to broker, send request, receive response.
 fn communicate(socket_path: &str, request: &[u8], timeout: Duration) -> Result<Response, String> {
-    let start = Instant::now();
-
     #[cfg(unix)]
     let stream = std::os::unix::net::UnixStream::connect(socket_path)
         .map_err(|e| format!("broker unavailable: {e}"))?;
@@ -222,11 +212,22 @@ fn communicate(socket_path: &str, request: &[u8], timeout: Duration) -> Result<R
     let stream = uds_windows::UnixStream::connect(socket_path)
         .map_err(|e| format!("broker unavailable: {e}"))?;
 
-    // Send request.
-    let remaining = remaining_timeout(start, timeout)?;
+    // Set both timeouts on the freshly-connected socket BEFORE any I/O.
+    // macOS rejects setsockopt(SO_*TIMEO) with EINVAL once the peer has
+    // closed: xnu's unp_disconnect calls soisdisconnected on us, which
+    // sets SS_CANTRCVMORE | SS_CANTSENDMORE, and sosetoptlock then
+    // refuses any further setsockopt. Under load the broker's
+    // resolve → shutdown(Both) → drop sequence can land before the
+    // interceptor reaches a post-write set_read_timeout, which is what
+    // produced the `set timeout: Invalid argument (os error 22)`
+    // failures observed in production.
     stream
-        .set_write_timeout(Some(remaining))
+        .set_write_timeout(Some(timeout))
         .map_err(|e| format!("set timeout: {e}"))?;
+    stream
+        .set_read_timeout(Some(timeout))
+        .map_err(|e| format!("set timeout: {e}"))?;
+
     (&stream)
         .write_all(request)
         .map_err(|e| format!("broker write failed: {e}"))?;
@@ -237,12 +238,6 @@ fn communicate(socket_path: &str, request: &[u8], timeout: Duration) -> Result<R
     // from writing the verdict back to the interceptor.
     #[cfg(unix)]
     tolerate_disconnected_shutdown(stream.shutdown(Shutdown::Write))?;
-
-    // Receive response with cumulative timeout and size limit.
-    let remaining = remaining_timeout(start, timeout)?;
-    stream
-        .set_read_timeout(Some(remaining))
-        .map_err(|e| format!("set timeout: {e}"))?;
 
     let mut line = String::new();
     io::BufReader::new((&stream).take(RESPONSE_MAX))

--- a/plugins/coding-agents-plugin/src/socket_server.rs
+++ b/plugins/coding-agents-plugin/src/socket_server.rs
@@ -173,6 +173,16 @@ fn run_server(
 
         match listener.accept() {
             Ok((stream, _)) => {
+                // macOS (and BSDs) inherit the listener's O_NONBLOCK onto
+                // accepted streams; Linux does not. Without this clear,
+                // `set_read_timeout` below is a no-op against `WouldBlock`
+                // and the first read of any request whose bytes haven't
+                // fully landed in the kernel buffer yet fails immediately,
+                // dropping the connection. This is what surfaced as
+                // "broker closed connection" / EPIPE / ENOTCONN on the
+                // interceptor side under load with payloads larger than
+                // the 8 KB Unix-socket sndbuf default.
+                let _ = stream.set_nonblocking(false);
                 let _ = stream.set_read_timeout(Some(CONNECTION_READ_TIMEOUT));
                 if let Err(e) = handle_connection(stream, event_tx, broker) {
                     log::warn!("connection error: {}", e);

--- a/plugins/coding-agents-plugin/src/socket_server.rs
+++ b/plugins/coding-agents-plugin/src/socket_server.rs
@@ -148,6 +148,99 @@ mod tests {
         drop(first);
         let _ = std::fs::remove_file(&path);
     }
+
+    /// Pins the post-accept `set_nonblocking(false)` fix in `run_server`.
+    ///
+    /// macOS's `accept(2)` inherits the listener's `O_NONBLOCK` onto the
+    /// accepted stream; Linux's does not, and Windows uses `uds_windows`
+    /// which doesn't share the BSD inheritance behavior either. Without
+    /// clearing the flag on the accepted side, `set_read_timeout` becomes
+    /// a no-op against `WouldBlock` and the first read on a request whose
+    /// bytes haven't fully landed in the kernel's 8 KB Unix-socket buffer
+    /// fails immediately, dropping the stream. On the interceptor side
+    /// this surfaced as "broker closed connection" / EPIPE / ENOTCONN
+    /// under concurrent load with payloads larger than 8 KB.
+    ///
+    /// macOS-only: the test relies on the kernel's actual inheritance
+    /// behavior rather than forcing it, so it would be testing nothing
+    /// meaningful on the other targets.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn accepted_stream_clears_inherited_nonblock_for_handle_connection_read() {
+        use std::io::{BufRead, BufReader, Read, Write};
+        use std::time::Duration;
+
+        let path = temp_socket_path("nonblock-clear-macos");
+        let _ = std::fs::remove_file(&path);
+
+        let listener = UnixListener::bind(&path).expect("bind");
+        listener
+            .set_nonblocking(true)
+            .expect("set_nonblocking on listener");
+
+        let client_path = path.clone();
+        let writer = std::thread::spawn(move || {
+            let mut client = UnixStream::connect(&client_path).expect("connect");
+            // Write the request in chunks with a pause between them so the
+            // broker's BufReader::read_line is FORCED to do a follow-up
+            // `fill_buf` against an empty kernel buffer. Without the fix
+            // line, that follow-up returns WouldBlock immediately even
+            // though set_read_timeout was set, because the accepted
+            // stream inherited the listener's non-blocking flag and
+            // SO_RCVTIMEO has no effect on a non-blocking socket.
+            for _ in 0..4 {
+                let chunk = vec![b'x'; 4 * 1024];
+                client.write_all(&chunk).expect("client write_all chunk");
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            client.write_all(b"\n").expect("client write \\n");
+            client
+                .shutdown(std::net::Shutdown::Write)
+                .expect("client shutdown WR");
+            // Block until the broker side closes its end. We must NOT drop
+            // here — if the writer's fd closes before the broker's
+            // `set_read_timeout` runs, `soisdisconnected` propagates onto
+            // the broker side and the setsockopt itself returns EINVAL on
+            // macOS, which would mask what this test is meant to pin down.
+            // The main thread drops its `stream` after the assertions so
+            // this read returns Ok(0) and the thread exits cleanly.
+            let _ = (&client).read(&mut [0u8; 1]);
+        });
+
+        // Poll-accept exactly like `run_server`'s loop.
+        let stream = loop {
+            match listener.accept() {
+                Ok((s, _)) => break s,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Err(e) => panic!("accept: {e}"),
+            }
+        };
+
+        // The fix: clear the flag macOS inherited from the listener.
+        // Removing this line makes the `read_line` below fail with
+        // `WouldBlock` (errno 35) immediately.
+        stream
+            .set_nonblocking(false)
+            .expect("clear inherited non-blocking on accepted stream");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("set_read_timeout");
+
+        let mut line = String::new();
+        BufReader::new((&stream).take(64 * 1024))
+            .read_line(&mut line)
+            .expect("read_line should succeed on a blocking stream");
+        assert_eq!(line.len(), 16 * 1024 + 1); // 4 × 4 KB chunks + '\n'
+        assert!(line.ends_with('\n'));
+
+        // Release the broker side so the writer's blocking read returns
+        // Ok(0) and its thread can exit; otherwise `join` deadlocks.
+        drop(stream);
+        writer.join().expect("writer thread panicked");
+        let _ = std::fs::remove_file(&path);
+    }
 }
 
 /// Accept loop. Listener is already bound. Same implementation on Unix and


### PR DESCRIPTION
The post-shutdown set_read_timeout races the broker's resolve+close. Once the peer drops, xnu sets both CANT* flags on us and rejects setsockopt with EINVAL. Setting both timeouts upfront on the fresh socket eliminates the race; the buffered response is still readable after the peer tears down.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area CI

> /area ctl

> /area documentation

> /area installer

/area interceptor

> /area plugin

> /area rules

> /area skills

> /area supervisor

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

