### PR TITLE
fix(windows): unblock fresh-install service start

### DIFF
--- a/installers/windows/prempti-launcher.ps1
+++ b/installers/windows/prempti-launcher.ps1
@@ -5,9 +5,11 @@
 
 .DESCRIPTION
     Hides the console window (via the PowerShell host invocation) and
-    invokes `premptictl daemon`. The supervisor owns the
-    Falco process, log files, rotation, and Claude Code hook lifecycle.
-    Runs in the foreground so the supervisor's stop signals reach it.
+    invokes `premptictl daemon`. The supervisor owns the Falco process,
+    log files, rotation, and Claude Code hook lifecycle. Runs in the
+    foreground so the supervisor's stop signals reach it. Captures the
+    supervisor's own stderr to log/supervisor.err so an early crash
+    (before Falco's logs are open) leaves a breadcrumb for the user.
 #>
 param(
     [string]$Prefix = (Join-Path $env:LOCALAPPDATA 'prempti')
@@ -17,5 +19,41 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Continue'
 
 $Ctl = Join-Path $Prefix 'bin\premptictl.exe'
-& $Ctl daemon --prefix $Prefix
-exit $LASTEXITCODE
+$LogDir = Join-Path $Prefix 'log'
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+}
+$SupervisorErr = Join-Path $LogDir 'supervisor.err'
+
+# Truncate per-run; only the latest launch's supervisor stderr is useful for
+# diagnosing a failed startup. Use UTF-8 without BOM so Add-Content / external
+# tools don't have to skip a BOM.
+[IO.File]::WriteAllText($SupervisorErr, '', [System.Text.UTF8Encoding]::new($false))
+
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $Ctl
+$psi.Arguments = "daemon --prefix `"$Prefix`""
+$psi.UseShellExecute = $false
+$psi.RedirectStandardError = $true
+$psi.CreateNoWindow = $true
+$proc = [System.Diagnostics.Process]::Start($psi)
+
+# Drain stderr asynchronously to avoid a 4 KB OS pipe-buffer deadlock if the
+# supervisor logs steadily. Each line is appended to supervisor.err.
+$drain = Register-ObjectEvent -InputObject $proc -EventName ErrorDataReceived -Action {
+    if ($EventArgs.Data) {
+        [IO.File]::AppendAllText($Event.MessageData, $EventArgs.Data + "`r`n",
+            [System.Text.UTF8Encoding]::new($false))
+    }
+} -MessageData $SupervisorErr
+$proc.BeginErrorReadLine()
+
+$proc.WaitForExit()
+# Per MSDN, calling WaitForExit() a second time after the first returns ensures
+# all async events fire before we tear down the registration.
+$proc.WaitForExit()
+
+if ($drain) {
+    Unregister-Event -SourceIdentifier $drain.Name -ErrorAction SilentlyContinue
+}
+exit $proc.ExitCode

--- a/installers/windows/scripts/postinstall.ps1
+++ b/installers/windows/scripts/postinstall.ps1
@@ -167,7 +167,6 @@ try {
 # ---------------------------------------------------------------------------
 
 $launcherScript = Join-Path $BinDir 'prempti-launcher.ps1'
-$installedFalco = Join-Path $BinDir 'falco.exe'
 if (Test-Path $launcherScript) {
   try {
     # Pass -Prefix so a custom install location picked via WixUI_InstallDir
@@ -191,65 +190,21 @@ if (Test-Path $launcherScript) {
 # ---------------------------------------------------------------------------
 # The Run key above only fires at next login. Bring the service up right
 # now so the Claude Code hook we just registered has a live broker to talk
-# to - otherwise fail-closed would block every tool call from the moment
-# the MSI finishes until the user's next logout/login.
-# Scope the detection by Path: a user running an unrelated Falco build in
-# another directory should not convince us to skip the start.
-
-# Match by Path so unrelated falco.exe instances (other projects, dev
-# builds) don't convince us to skip our own start. Guard .Path access
-# with try/catch: on a process running under a different account it
-# throws Win32Exception instead of returning $null, which would bubble
-# past -ErrorAction SilentlyContinue.
-function Test-InstalledFalcoRunning {
-    param([string]$TargetPath)
-    foreach ($p in Get-Process -Name falco -ErrorAction SilentlyContinue) {
-        try {
-            if ($p.Path -and ($p.Path -eq $TargetPath)) { return $true }
-        } catch {
-            # Access denied: not our process. Keep scanning.
-        }
+# to — otherwise fail-closed would block every tool call from the moment
+# the MSI finishes until the user's next logout/login. `premptictl start`
+# spawns the launcher detached, polls for readiness, and exits non-zero
+# with a pointer to the supervisor and Falco logs on failure.
+$startOk = $false
+if (Test-Path $ctlExe) {
+    & $ctlExe start
+    $startOk = ($LASTEXITCODE -eq 0)
+    if (-not $startOk) {
+        Write-Warning "Service did not start. Run 'premptictl start' manually and check the supervisor and Falco logs under $LogDir."
     }
-    return $false
 }
 
-$falcoRunning = Test-InstalledFalcoRunning -TargetPath $installedFalco
-if (-not $falcoRunning -and (Test-Path $launcherScript)) {
-    try {
-        # Pre-quote the path arguments. Start-Process -ArgumentList joins
-        # the array with bare spaces and does NOT quote elements that
-        # contain spaces, so a custom INSTALLDIR like "C:\Program
-        # Files\prempti" would otherwise be split before
-        # reaching the spawned powershell.
-        $quotedLauncher = '"' + $launcherScript + '"'
-        $quotedPrefix = '"' + $Prefix + '"'
-        $startArgs = @(
-            '-NoProfile',
-            '-ExecutionPolicy', 'Bypass',
-            '-WindowStyle', 'Hidden',
-            '-File', $quotedLauncher,
-            '-Prefix', $quotedPrefix
-        )
-        Start-Process -FilePath 'powershell.exe' -ArgumentList $startArgs -WindowStyle Hidden | Out-Null
-        # Wait up to 5s for Falco to appear before declaring success.
-        $started = $false
-        for ($i = 0; $i -lt 20; $i++) {
-            Start-Sleep -Milliseconds 250
-            if (Test-InstalledFalcoRunning -TargetPath $installedFalco) {
-                $started = $true
-                break
-            }
-        }
-        if ($started) {
-            Write-Host "Service started."
-        } else {
-            Write-Warning "Service start kicked off but Falco not detected yet. Check 'premptictl status' and the startup log at $LogDir\falco.err."
-        }
-    } catch {
-        Write-Warning "Could not start the service: $($_.Exception.Message). Run 'premptictl start' manually and check $LogDir\falco.err."
-    }
-} elseif ($falcoRunning) {
-    Write-Host "Service already running."
+if ($startOk) {
+    Write-Host "Post-install complete: Prempti is installed, configured, and running."
+} else {
+    Write-Host "Post-install complete: Prempti is installed and configured. The service is not running yet."
 }
-
-Write-Host "Post-install complete: Prempti is installed, configured, and running."

--- a/installers/windows/scripts/postinstall.ps1
+++ b/installers/windows/scripts/postinstall.ps1
@@ -32,6 +32,12 @@ foreach ($dir in @($ConfigDir, $RunDir, $LogDir)) {
     New-Item -ItemType Directory -Force -Path $dir | Out-Null
 }
 
+# PS 5.1's `Set-Content -Encoding UTF8` writes a UTF-8 BOM. The supervisor
+# YAML loader rejects a leading BOM; emit no-BOM so configs parse cleanly.
+function Set-Utf8NoBom([string]$Path, [string]$Content) {
+    [IO.File]::WriteAllText($Path, $Content, [System.Text.UTF8Encoding]::new($false))
+}
+
 # ---------------------------------------------------------------------------
 # Generate falco.yaml with resolved Windows paths
 # ---------------------------------------------------------------------------
@@ -68,7 +74,7 @@ priority: debug
 watch_config_files: false
 "@
 
-Set-Content -Path (Join-Path $ConfigDir 'falco.yaml') -Value $falcoYaml -Encoding UTF8
+Set-Utf8NoBom (Join-Path $ConfigDir 'falco.yaml') $falcoYaml
 Write-Host "Generated falco.yaml"
 
 # ---------------------------------------------------------------------------
@@ -86,7 +92,7 @@ log_rotate_bytes: 10485760    # 10 MiB
 log_rotate_keep: 3
 stop_timeout_secs: 20
 "@
-    Set-Content -Path $SupervisorYamlPath -Value $supervisorYaml -Encoding UTF8
+    Set-Utf8NoBom $SupervisorYamlPath $supervisorYaml
     Write-Host "Generated supervisor.yaml"
 } else {
     Write-Host "Preserving existing supervisor.yaml"
@@ -120,7 +126,7 @@ append_output:
     extra_output: " | For AI Agents: inform the user that this action was flagged by a Falco rule | correlation=%correlation.id"
 "@
 
-Set-Content -Path (Join-Path $ConfigDir 'falco.coding_agents_plugin.yaml') -Value $pluginYaml -Encoding UTF8
+Set-Utf8NoBom (Join-Path $ConfigDir 'falco.coding_agents_plugin.yaml') $pluginYaml
 Write-Host "Generated falco.coding_agents_plugin.yaml"
 
 # ---------------------------------------------------------------------------

--- a/tools/premptictl/src/daemon/config.rs
+++ b/tools/premptictl/src/daemon/config.rs
@@ -36,6 +36,7 @@ impl SupervisorConfig {
     }
 
     fn parse_with_warnings(data: &str, source: &Path) -> Result<Self, String> {
+        let data = data.strip_prefix('\u{FEFF}').unwrap_or(data);
         let mut cfg = Self::default();
         for (idx, raw) in data.lines().enumerate() {
             let line_num = idx + 1;
@@ -164,5 +165,12 @@ log_rotate_bytes: 9999
         let path = PathBuf::from("/nonexistent/supervisor.yaml");
         let cfg = SupervisorConfig::load(&path).unwrap();
         assert_eq!(cfg, SupervisorConfig::default());
+    }
+
+    #[test]
+    fn tolerates_utf8_bom() {
+        let yaml = "\u{FEFF}log_rotate_bytes: 4096\n";
+        let cfg = SupervisorConfig::parse_with_warnings(yaml, &fake_path()).unwrap();
+        assert_eq!(cfg.log_rotate_bytes, 4096);
     }
 }

--- a/tools/premptictl/src/main.rs
+++ b/tools/premptictl/src/main.rs
@@ -616,9 +616,9 @@ fn service_start(prefix: &PathBuf) {
         eprintln!("Failed to start service.");
         process::exit(1);
     }
-    // Poll briefly to verify Falco actually started.
+    // Poll up to 10s to verify Falco actually started.
     let mut started = false;
-    for _ in 0..6 {
+    for _ in 0..20 {
         std::thread::sleep(std::time::Duration::from_millis(500));
         if installed_falco_pids(prefix).is_some() {
             started = true;
@@ -628,7 +628,11 @@ fn service_start(prefix: &PathBuf) {
     if started {
         println!("Service started.");
     } else {
-        println!("Service starting (Falco not yet detected \u{2014} check logs).");
+        eprintln!("Service did not start within 10 seconds.");
+        eprintln!("Check logs:");
+        eprintln!("  {}", prefix.join("log").join("supervisor.err").display());
+        eprintln!("  {}", prefix.join("log").join("falco.err").display());
+        process::exit(1);
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area CI

/area ctl

> /area documentation

/area installer

> /area interceptor

> /area plugin

> /area rules

> /area skills

/area supervisor

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fixes the v0.2.1-rc1 install-time blocker on Windows: `postinstall.ps1` wrote configs as UTF-8 + BOM (PS 5.1's `Set-Content -Encoding UTF8` default), the supervisor's YAML loader rejected the BOM at line 1, the daemon crashed before spawning Falco, and the hook stayed registered → fail-closed for every fresh Windows install.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

