### PR TITLE
Opt-in fail-open hook and experimental passthrough mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,27 +160,18 @@ Note: Falco's alert delivery is asynchronous — alerts are pushed to an interna
 
 ### Operational modes
 
-Two plugin modes, switchable without reinstallation via `premptictl mode <guardrails|monitor>`:
+Three plugin modes, switchable without reinstallation via `premptictl mode <guardrails|monitor|passthrough>`:
 - **Guardrails** (default) — verdicts enforced (deny/ask/allow).
-- **Monitor** — rules evaluated and logged, but all verdicts resolve to allow.
+- **Monitor** — rules evaluated and logged, but all verdicts resolve to allow after the synchronous rule-eval wait. Would-deny / would-ask log lines still fire.
+- **Passthrough** (Experimental, embedding-only) — every interceptor request is resolved as `allow` immediately at register, without waiting for rule evaluation. Events are still enqueued for Falco, so alerts continue to flow through `http_output` / `falco.log` and any observability pipeline hanging off them. No would-deny / would-ask log lines, because rule evaluation is decoupled from the verdict. Use only when embedding Prempti inside a host agent that has its own alert pipeline and does not want the hook's latency tied to Falco's rule loop.
+
+The three modes are mutually exclusive — `mode:` is a single string, so `monitor` and `passthrough` cannot coexist.
 
 Mode changes are applied via an explicit service restart driven by `ctl mode`: it rewrites the plugin config fragment, stops the service, re-registers the interceptor hook (so the brief restart window stays fail-closed rather than passing tool calls through unchecked), and starts the service again. Behavior is identical on Linux, macOS, and Windows. The same flow applies to any other config edit: edits made directly to `falco.yaml` or any included config / rule file take effect on the next `ctl start` (or `ctl mode`) — Falco's own `watch_config_files` is disabled deliberately because it is Linux-only upstream.
 
 `ctl restart` exposes the same stop → re-add hook → start cycle as a standalone command for users who edit config files directly.
 
-Additionally, the interceptor hook can be unregistered via `premptictl hook remove`, which passes all tool calls through unmonitored (neither mode is active because the hook isn't firing). This is effectively a hook-removed bypass used when the service is intentionally stopped, and is distinct from the in-plugin `passthrough` knob described next.
-
-#### Passthrough (Experimental)
-
-`init_config.passthrough: true` short-circuits the broker: every interceptor request is resolved as `allow` immediately at register, without waiting for rule evaluation. The event is still enqueued for Falco, so alerts continue to flow through `http_output` / `falco.log` and any observability pipeline hanging off them.
-
-When to use it: embedding Prempti inside a host agent that has its own alert pipeline and does not want the hook's latency tied to Falco's rule loop.
-
-Difference from `mode: monitor`:
-- **Monitor**: synchronous wait — the broker waits for the rule batch to complete, then forces the verdict to `allow`. Would-deny / would-ask log lines fire.
-- **Passthrough**: no wait — the broker writes `allow` to the interceptor at register and never inserts into the pending map. No would-deny / would-ask log lines, because rule evaluation is decoupled from the verdict.
-
-Precedence: if both `passthrough: true` and `mode: monitor` are set, passthrough wins — the synchronous wait never happens and monitor's would-deny/would-ask log lines do not fire. The plugin logs a warning on startup when this combination is detected.
+Additionally, the interceptor hook can be unregistered via `premptictl hook remove`, which passes all tool calls through unmonitored (no mode is active because the hook isn't firing). This is a hook-removed bypass used when the service is intentionally stopped, and is distinct from `mode: passthrough` which keeps the hook live but short-circuits the broker.
 
 ### Supervisor (`ctl daemon`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,19 @@ Mode changes are applied via an explicit service restart driven by `ctl mode`: i
 
 `ctl restart` exposes the same stop → re-add hook → start cycle as a standalone command for users who edit config files directly.
 
-Additionally, the interceptor hook can be unregistered via `premptictl hook remove`, which passes all tool calls through unmonitored (neither mode is active because the hook isn't firing). This is effectively a "passthrough" state used when the service is intentionally stopped.
+Additionally, the interceptor hook can be unregistered via `premptictl hook remove`, which passes all tool calls through unmonitored (neither mode is active because the hook isn't firing). This is effectively a hook-removed bypass used when the service is intentionally stopped, and is distinct from the in-plugin `passthrough` knob described next.
+
+#### Passthrough (Experimental)
+
+`init_config.passthrough: true` short-circuits the broker: every interceptor request is resolved as `allow` immediately at register, without waiting for rule evaluation. The event is still enqueued for Falco, so alerts continue to flow through `http_output` / `falco.log` and any observability pipeline hanging off them.
+
+When to use it: embedding Prempti inside a host agent that has its own alert pipeline and does not want the hook's latency tied to Falco's rule loop.
+
+Difference from `mode: monitor`:
+- **Monitor**: synchronous wait — the broker waits for the rule batch to complete, then forces the verdict to `allow`. Would-deny / would-ask log lines fire.
+- **Passthrough**: no wait — the broker writes `allow` to the interceptor at register and never inserts into the pending map. No would-deny / would-ask log lines, because rule evaluation is decoupled from the verdict.
+
+Precedence: if both `passthrough: true` and `mode: monitor` are set, passthrough wins — the synchronous wait never happens and monitor's would-deny/would-ask log lines do not fire. The plugin logs a warning on startup when this combination is detected.
 
 ### Supervisor (`ctl daemon`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,13 @@ make falco-windows          # Build only Falco (convenience target)
 | `PREMPTI_SOCKET` | `~/.prempti/run/broker.sock` | Broker Unix socket path |
 | `PREMPTI_TIMEOUT_MS` | `5000` | Socket read timeout in milliseconds |
 
+Boolean Prempti env vars are parsed by the `env_bool` helper in
+`hooks/claude-code/src/main.rs`: it accepts `1`, `true`, `yes`, `on`
+(case-insensitive, surrounding whitespace ignored) as truthy; everything
+else — including unset and empty — is falsy. `PREMPTI_TIMEOUT_MS` is
+numeric and `NO_COLOR` follows the external "any non-empty = true"
+convention; `env_bool` is the convention for new Prempti booleans only.
+
 ## Code Style
 
 ### License headers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ Three plugin modes, switchable without reinstallation via `premptictl mode <guar
 - **Monitor** — rules evaluated and logged, but all verdicts resolve to allow after the synchronous rule-eval wait. Would-deny / would-ask log lines still fire.
 - **Passthrough** (Experimental, embedding-only) — every interceptor request is resolved as `allow` immediately at register, without waiting for rule evaluation. Events are still enqueued for Falco, so alerts continue to flow through `http_output` / `falco.log` and any observability pipeline hanging off them. No would-deny / would-ask log lines, because rule evaluation is decoupled from the verdict. Use only when embedding Prempti inside a host agent that has its own alert pipeline and does not want the hook's latency tied to Falco's rule loop.
 
-The three modes are mutually exclusive — `mode:` is a single string, so `monitor` and `passthrough` cannot coexist.
+The three modes are mutually exclusive — `mode:` is a single string, so only one is active at a time.
 
 Mode changes are applied via an explicit service restart driven by `ctl mode`: it rewrites the plugin config fragment, stops the service, re-registers the interceptor hook (so the brief restart window stays fail-closed rather than passing tool calls through unchecked), and starts the service again. Behavior is identical on Linux, macOS, and Windows. The same flow applies to any other config edit: edits made directly to `falco.yaml` or any included config / rule file take effect on the next `ctl start` (or `ctl mode`) — Falco's own `watch_config_files` is disabled deliberately because it is Linux-only upstream.
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -25,14 +25,14 @@ Contains:
 - `rules_files` (default rules → user rules → seen rule)
 - `http_output` configuration
 
-#### `passthrough` (Experimental)
+#### `mode: passthrough` (Experimental)
 
-Embedding-only knob. When `true`, all interceptor requests are resolved
-as `allow` immediately at register, without waiting for rule evaluation.
-Events are still enqueued for Falco so observability via `http_output`
-and `falco.log` is preserved. Defaults to `false`.
+Embedding-only mode. When `mode: passthrough` is set, all interceptor
+requests are resolved as `allow` immediately at register, without
+waiting for rule evaluation. Events are still enqueued for Falco so
+observability via `http_output` and `falco.log` is preserved.
 
-Use this only when embedding Prempti inside a host agent that handles
+Use only when embedding Prempti inside a host agent that handles
 alerts via its own pipeline.
 
 This is distinct from `mode: monitor`: monitor waits for rule

--- a/configs/README.md
+++ b/configs/README.md
@@ -25,6 +25,21 @@ Contains:
 - `rules_files` (default rules → user rules → seen rule)
 - `http_output` configuration
 
+#### `passthrough` (Experimental)
+
+Embedding-only knob. When `true`, all interceptor requests are resolved
+as `allow` immediately at register, without waiting for rule evaluation.
+Events are still enqueued for Falco so observability via `http_output`
+and `falco.log` is preserved. Defaults to `false`.
+
+Use this only when embedding Prempti inside a host agent that handles
+alerts via its own pipeline.
+
+This is distinct from `mode: monitor`: monitor waits for rule
+evaluation and then forces an `allow` verdict (synchronous, so
+would-deny/would-ask log lines fire), while passthrough short-circuits
+at register and skips the wait entirely.
+
 ## Path Expansion
 
 All paths use `${HOME}` expansion (Falco native, `${VAR}` syntax). No hardcoded paths.

--- a/configs/falco.coding_agents_plugin.yaml
+++ b/configs/falco.coding_agents_plugin.yaml
@@ -5,17 +5,21 @@ plugins:
   - name: coding_agent
     library_path: ${HOME}/.prempti/share/libcoding_agent.so
     init_config:
-      # Operational mode: "guardrails" (default) or "monitor".
-      # In monitor mode, rules are evaluated and logged but all verdicts resolve as allow.
-      # Changed via: premptictl mode <guardrails|monitor>
+      # Operational mode. One of:
+      #   guardrails (default): verdicts enforced (deny/ask/allow).
+      #   monitor:              rules evaluated and logged, but all
+      #                         verdicts resolve as allow after the
+      #                         synchronous rule-eval wait.
+      #   passthrough (EXPERIMENTAL, embedding-only): every interceptor
+      #                         request resolves as allow immediately at
+      #                         register, without waiting for rule
+      #                         evaluation. Events are still enqueued for
+      #                         Falco so observability via http_output /
+      #                         falco.log is preserved. Use only when
+      #                         embedding Prempti inside a host agent
+      #                         that handles alerts via its own pipeline.
+      # Changed via: premptictl mode <guardrails|monitor|passthrough>
       mode: guardrails
-      # EXPERIMENTAL — embedding-only. When true, all interceptor requests
-      # are resolved as "allow" immediately, without waiting for rule
-      # evaluation. Events are still enqueued for Falco so observability
-      # via http_output / falco.log is preserved. Use this only when
-      # embedding Prempti inside a host agent that handles alerts via its
-      # own pipeline.
-      # passthrough: false
       socket_path: ${HOME}/.prempti/run/broker.sock
       http_port: 2802
 

--- a/configs/falco.coding_agents_plugin.yaml
+++ b/configs/falco.coding_agents_plugin.yaml
@@ -9,6 +9,13 @@ plugins:
       # In monitor mode, rules are evaluated and logged but all verdicts resolve as allow.
       # Changed via: premptictl mode <guardrails|monitor>
       mode: guardrails
+      # EXPERIMENTAL — embedding-only. When true, all interceptor requests
+      # are resolved as "allow" immediately, without waiting for rule
+      # evaluation. Events are still enqueued for Falco so observability
+      # via http_output / falco.log is preserved. Use this only when
+      # embedding Prempti inside a host agent that handles alerts via its
+      # own pipeline.
+      # passthrough: false
       socket_path: ${HOME}/.prempti/run/broker.sock
       http_port: 2802
 

--- a/docs/hooks/claude-code/SPEC.md
+++ b/docs/hooks/claude-code/SPEC.md
@@ -16,7 +16,7 @@ The interceptor is a **thin passthrough** — it does not interpret tool call co
 
 1. **No content interpretation**: The interceptor treats the stdin JSON as an opaque payload. The only field it reads is `tool_use_id` (for the wire protocol request ID).
 2. **Fail-safe output**: Every code path either produces valid JSON on stdout (exit 0) or blocks the tool call (exit 2). Empty stdout with exit 0 is prevented by design.
-3. **Fail-closed**: If the broker is unreachable, the tool call is denied. There is no fail-open mode.
+3. **Fail-closed by default**: If the broker is unreachable, the tool call is denied. Embedding integrations may opt into fail-open via `PREMPTI_FAIL_OPEN=1`.
 4. **Minimal dependencies**: Only `serde`/`serde_json` and the Rust standard library. No async runtime.
 
 ## Execution Model
@@ -140,7 +140,7 @@ The `event` field contains the entire Claude Code hook input verbatim. The broke
 - `id` matches the request's correlation ID
 - `decision` is one of `allow`, `deny`, `ask`
 
-Failures trigger `verdict_on_error` (always fail-closed: deny).
+Failures trigger `verdict_on_error` (fail-closed by default: deny).
 
 ## Error Handling
 
@@ -149,11 +149,11 @@ Failures trigger `verdict_on_error` (always fail-closed: deny).
 | Category | Trigger | Behavior |
 |----------|---------|----------|
 | **Input error** | Empty stdin, invalid JSON, invalid UTF-8, oversized input (>64KB) | Exit code 2, stderr message |
-| **Broker error** | Socket unavailable, write/read failure, timeout, malformed response, ID mismatch, invalid decision | Deny (fail-closed) |
+| **Broker error** | Socket unavailable, write/read failure, timeout, malformed response, ID mismatch, invalid decision | Deny by default; allow if `PREMPTI_FAIL_OPEN=1` |
 
-### Fail-closed
+### Fail-closed by default
 
-All broker errors result in deny. There is no fail-open mode. The hook lifecycle is tied to the systemd service — when the service stops, the hook is removed, so fail-closed cannot brick Claude Code during intentional downtime.
+All broker errors result in deny unless `PREMPTI_FAIL_OPEN=1` is set. This preserves standalone/default behavior while letting embedding integrations opt into fail-open operation when broker unavailability should not block tool execution.
 
 ### Stdout safety
 
@@ -165,6 +165,7 @@ If JSON serialization fails, the interceptor emits a hardcoded deny JSON literal
 |----------|----------------|-------------------|-------------|
 | `PREMPTI_SOCKET` | `$HOME/.prempti/run/broker.sock` | `%LOCALAPPDATA%/prempti/run/broker.sock` | Broker socket path |
 | `PREMPTI_TIMEOUT_MS` | `5000` | `5000` | Socket timeout in ms (clamped to 100–30000) |
+| `PREMPTI_FAIL_OPEN` | `0` | `0` | When set to `1`/`true`, broker communication failures allow the tool call instead of denying it |
 
 ## Limits
 

--- a/hooks/claude-code/README.md
+++ b/hooks/claude-code/README.md
@@ -29,9 +29,10 @@ The interceptor reads only `tool_use_id` from the input (for the wire protocol r
 |----------|---------|-------------|
 | `PREMPTI_SOCKET` | `~/.prempti/run/broker.sock` | Broker socket path |
 | `PREMPTI_TIMEOUT_MS` | `5000` | Socket timeout in ms |
+| `PREMPTI_FAIL_OPEN` | `0` | When set to `1`/`true`, broker communication failures allow the tool call instead of denying it |
 
 ## Error Handling
 
-- **Fail-closed**: All broker communication failures result in deny.
+- **Fail-closed by default**: Broker communication failures deny unless `PREMPTI_FAIL_OPEN=1` is set.
 - **Exit code 2**: For malformed input (empty stdin, invalid JSON). Claude Code blocks the tool call.
 - **Stdout safety**: If JSON serialization fails, emits a hardcoded deny literal. No path produces empty stdout with exit 0.

--- a/hooks/claude-code/src/main.rs
+++ b/hooks/claude-code/src/main.rs
@@ -469,4 +469,51 @@ mod tests {
         let r = tolerate_disconnected_shutdown(a.shutdown(Shutdown::Write));
         assert!(r.is_ok(), "expected tolerance, got {r:?}");
     }
+
+    // env_bool is process-global through std::env::var. Each test below uses a
+    // unique var name to avoid racing with other tests running in parallel,
+    // and removes the var at the end so reruns are clean.
+
+    #[test]
+    fn env_bool_unset_is_false() {
+        let name = "PREMPTI_TEST_ENV_BOOL_UNSET";
+        env::remove_var(name);
+        assert!(!env_bool(name));
+    }
+
+    #[test]
+    fn env_bool_one_is_true() {
+        let name = "PREMPTI_TEST_ENV_BOOL_ONE";
+        env::set_var(name, "1");
+        assert!(env_bool(name));
+        env::remove_var(name);
+    }
+
+    #[test]
+    fn env_bool_true_case_insensitive() {
+        let name = "PREMPTI_TEST_ENV_BOOL_TRUE";
+        for v in ["true", "TRUE", "True"] {
+            env::set_var(name, v);
+            assert!(env_bool(name), "{v} should be truthy");
+        }
+        env::remove_var(name);
+    }
+
+    #[test]
+    fn env_bool_trims_whitespace() {
+        let name = "PREMPTI_TEST_ENV_BOOL_WS";
+        env::set_var(name, " 1 ");
+        assert!(env_bool(name));
+        env::remove_var(name);
+    }
+
+    #[test]
+    fn env_bool_falsy_values() {
+        let name = "PREMPTI_TEST_ENV_BOOL_FALSY";
+        for v in ["0", "", "no", "off", "false", "anything"] {
+            env::set_var(name, v);
+            assert!(!env_bool(name), "{v:?} should be falsy");
+        }
+        env::remove_var(name);
+    }
 }

--- a/hooks/claude-code/src/main.rs
+++ b/hooks/claude-code/src/main.rs
@@ -140,14 +140,43 @@ fn verdict_deny(reason: &str) -> ! {
     process::exit(0);
 }
 
-/// Broker communication failure — always deny (fail-closed).
+/// Broker communication failure — deny by default (fail-closed).
+///
+/// Upstream interceptor semantics remain fail-closed unless an integration
+/// explicitly opts into fail-open via PREMPTI_FAIL_OPEN=1.
+///
+/// This keeps the standalone/default behavior unchanged while allowing
+/// embedding environments to continue operating when the broker is
+/// unavailable, at the cost of losing observability for that interval.
 fn verdict_on_error(reason: &str) -> ! {
-    verdict_deny(reason);
+    if env_bool("PREMPTI_FAIL_OPEN") {
+        write_verdict("allow", reason);
+        process::exit(0);
+    } else {
+        verdict_deny(reason);
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
+
+/// Parse a project env var as boolean. Returns true when the var is set to one
+/// of: 1, true, yes, on (case-insensitive, surrounding whitespace ignored).
+/// Returns false otherwise, including when the var is unset or set to an empty
+/// string.
+fn env_bool(name: &str) -> bool {
+    env::var(name)
+        .ok()
+        .map(|v| {
+            let s = v.trim();
+            s.eq_ignore_ascii_case("1")
+                || s.eq_ignore_ascii_case("true")
+                || s.eq_ignore_ascii_case("yes")
+                || s.eq_ignore_ascii_case("on")
+        })
+        .unwrap_or(false)
+}
 
 fn get_socket_path() -> String {
     if let Ok(v) = env::var("PREMPTI_SOCKET") {

--- a/plugins/coding-agents-plugin/src/broker.rs
+++ b/plugins/coding-agents-plugin/src/broker.rs
@@ -93,12 +93,13 @@ impl Broker {
         NEXT_CORRELATION_ID.fetch_add(1, Ordering::Relaxed)
     }
 
-    /// Set the operational mode. In monitor mode, all verdicts resolve as allow.
+    /// Set monitor mode. When enabled, all verdicts resolve as allow after
+    /// the synchronous rule-eval wait. Independent of passthrough mode.
     pub fn set_monitor_mode(&self, enabled: bool) {
         self.monitor_mode.store(enabled, Ordering::Relaxed);
         log::info!(
-            "broker mode: {}",
-            if enabled { "monitor" } else { "guardrails" }
+            "broker monitor: {}",
+            if enabled { "enabled" } else { "disabled" }
         );
     }
 

--- a/plugins/coding-agents-plugin/src/broker.rs
+++ b/plugins/coding-agents-plugin/src/broker.rs
@@ -470,4 +470,32 @@ mod tests {
         assert_eq!(n, 0);
         assert_eq!(broker.pending_count(), 1);
     }
+
+    #[test]
+    fn passthrough_allows_immediately_and_skips_pending() {
+        let broker = Broker::new();
+        broker.set_passthrough(true);
+        let peer = register_with(&broker, 1, "wire-1");
+        // Allow JSON is on the wire right away — no apply_* call needed.
+        let resp = read_response_json(&peer);
+        assert_eq!(resp["decision"], "allow");
+        assert_eq!(resp["id"], "wire-1");
+        // Pending map must stay empty: passthrough short-circuits before insert.
+        assert_eq!(broker.pending_count(), 0);
+    }
+
+    #[test]
+    fn passthrough_disabled_keeps_default_register_behavior() {
+        // Default (passthrough=false): entry inserted, stream stays open until
+        // a verdict is applied.
+        let broker = Broker::new();
+        assert!(!broker.is_passthrough());
+        let peer = register_with(&broker, 1, "wire-1");
+        assert_eq!(broker.pending_count(), 1);
+        expect_no_response(&peer);
+        // Resolve so the stream/peer drop cleanly.
+        broker.apply_deny(1, "cleanup".to_string());
+        let _ = read_response_json(&peer);
+        assert_eq!(broker.pending_count(), 0);
+    }
 }

--- a/plugins/coding-agents-plugin/src/broker.rs
+++ b/plugins/coding-agents-plugin/src/broker.rs
@@ -46,6 +46,8 @@ pub struct Broker {
     pending: DashMap<u64, PendingRequest>,
     /// When true, all verdicts resolve as allow (monitor mode).
     monitor_mode: AtomicBool,
+    /// When true, resolve all requests as allow immediately on register.
+    passthrough: AtomicBool,
     /// Shutdown signal for background threads.
     shutdown: AtomicBool,
 }
@@ -67,6 +69,7 @@ impl Broker {
         Broker {
             pending: DashMap::new(),
             monitor_mode: AtomicBool::new(false),
+            passthrough: AtomicBool::new(false),
             shutdown: AtomicBool::new(false),
         }
     }
@@ -99,6 +102,22 @@ impl Broker {
         );
     }
 
+    /// Set passthrough mode. When enabled, all interceptor requests are resolved
+    /// as "allow" immediately upon registration, without waiting for rule evaluation.
+    /// Events are still enqueued for the Falco engine to process.
+    pub fn set_passthrough(&self, enabled: bool) {
+        self.passthrough.store(enabled, Ordering::Relaxed);
+        log::info!(
+            "broker passthrough: {}",
+            if enabled { "enabled" } else { "disabled" }
+        );
+    }
+
+    /// Returns true if passthrough mode is active.
+    pub fn is_passthrough(&self) -> bool {
+        self.passthrough.load(Ordering::Relaxed)
+    }
+
     /// Returns true if monitor mode is active.
     fn is_monitor(&self) -> bool {
         self.monitor_mode.load(Ordering::Relaxed)
@@ -107,7 +126,18 @@ impl Broker {
     /// Register a new pending request. `correlation_id` is the broker-assigned ID
     /// used for Falco alert correlation. `wire_id` is the interceptor's request ID
     /// used in the verdict response.
+    ///
+    /// In passthrough mode, the request is resolved as "allow" immediately without
+    /// being added to the pending map.
     pub fn register(&self, correlation_id: u64, wire_id: String, stream: BrokerStream) {
+        if self.is_passthrough() {
+            let response = Verdict::Allow.to_response_json(&wire_id);
+            let mut s = stream;
+            let _ = write!(s, "{}\n", response);
+            let _ = s.flush();
+            let _ = s.shutdown(Shutdown::Both);
+            return;
+        }
         self.pending.insert(
             correlation_id,
             PendingRequest {

--- a/plugins/coding-agents-plugin/src/config.rs
+++ b/plugins/coding-agents-plugin/src/config.rs
@@ -19,6 +19,13 @@ pub struct CodingAgentConfig {
     #[serde(default = "default_http_port")]
     pub http_port: u16,
 
+    /// When true, resolve all interceptor requests as "allow" immediately,
+    /// without waiting for rule evaluation. Events are still enqueued for
+    /// processing. Useful when embedded in a host agent that handles alerts
+    /// through its own pipeline instead of Falco's http_output.
+    #[serde(default)]
+    pub passthrough: bool,
+
     /// Tags that indicate a deny verdict.
     #[serde(default = "default_deny_tags")]
     pub deny_tags: Vec<String>,

--- a/plugins/coding-agents-plugin/src/config.rs
+++ b/plugins/coding-agents-plugin/src/config.rs
@@ -6,8 +6,16 @@ use falco_plugin::serde::Deserialize;
 #[schemars(crate = "falco_plugin::schemars")]
 #[serde(crate = "falco_plugin::serde")]
 pub struct CodingAgentConfig {
-    /// Operational mode: "guardrails" (default) or "monitor".
-    /// In monitor mode, rules are evaluated and logged but all verdicts resolve as allow.
+    /// Operational mode. One of:
+    /// - `guardrails` (default): verdicts enforced (deny / ask / allow).
+    /// - `monitor`: rules are evaluated and logged, but all verdicts resolve
+    ///   as `allow` after the synchronous rule-eval wait.
+    /// - `passthrough` (Experimental): every interceptor request is resolved
+    ///   as `allow` immediately at register, without waiting for rule
+    ///   evaluation. Events are still enqueued so observability via
+    ///   `http_output` / `falco.log` is preserved. Use only when embedding
+    ///   Prempti inside a host agent that handles alerts through its own
+    ///   pipeline.
     #[serde(default = "default_mode")]
     pub mode: String,
 
@@ -18,15 +26,6 @@ pub struct CodingAgentConfig {
     /// Port for the HTTP alert receiver.
     #[serde(default = "default_http_port")]
     pub http_port: u16,
-
-    /// Experimental: when true, resolve all interceptor requests as "allow"
-    /// immediately, without waiting for rule evaluation. Events are still
-    /// enqueued for processing. Useful when embedded in a host agent that
-    /// handles alerts through its own pipeline instead of Falco's
-    /// http_output. Distinct from `mode: monitor`, which evaluates rules
-    /// synchronously and only then forces an allow verdict.
-    #[serde(default)]
-    pub passthrough: bool,
 
     /// Tags that indicate a deny verdict.
     #[serde(default = "default_deny_tags")]

--- a/plugins/coding-agents-plugin/src/config.rs
+++ b/plugins/coding-agents-plugin/src/config.rs
@@ -19,10 +19,12 @@ pub struct CodingAgentConfig {
     #[serde(default = "default_http_port")]
     pub http_port: u16,
 
-    /// When true, resolve all interceptor requests as "allow" immediately,
-    /// without waiting for rule evaluation. Events are still enqueued for
-    /// processing. Useful when embedded in a host agent that handles alerts
-    /// through its own pipeline instead of Falco's http_output.
+    /// Experimental: when true, resolve all interceptor requests as "allow"
+    /// immediately, without waiting for rule evaluation. Events are still
+    /// enqueued for processing. Useful when embedded in a host agent that
+    /// handles alerts through its own pipeline instead of Falco's
+    /// http_output. Distinct from `mode: monitor`, which evaluates rules
+    /// synchronously and only then forces an allow verdict.
     #[serde(default)]
     pub passthrough: bool,
 

--- a/plugins/coding-agents-plugin/src/lib.rs
+++ b/plugins/coding-agents-plugin/src/lib.rs
@@ -87,10 +87,10 @@ impl Plugin for CodingAgentPlugin {
         // is false) — which is the safer default but hides the user's
         // configuration mistake.
         match config.mode.as_str() {
-            "guardrails" | "monitor" => {}
+            "guardrails" | "monitor" | "passthrough" => {}
             other => {
                 return Err(anyhow::anyhow!(
-                    "invalid plugin mode '{other}': must be 'guardrails' or 'monitor'"
+                    "invalid plugin mode '{other}': must be 'guardrails', 'monitor', or 'passthrough'"
                 ));
             }
         }
@@ -106,15 +106,7 @@ impl Plugin for CodingAgentPlugin {
             bounded(DEFAULT_QUEUE_CAPACITY);
         let broker = Arc::new(Broker::new());
         broker.set_monitor_mode(config.mode == "monitor");
-        broker.set_passthrough(config.passthrough);
-        if config.passthrough && config.mode == "monitor" {
-            log::warn!(
-                "passthrough=true and mode=monitor are both set; \
-                 passthrough takes precedence — all requests will be \
-                 allowed immediately without rule-eval wait, and \
-                 monitor's would-deny/would-ask log lines will not fire"
-            );
-        }
+        broker.set_passthrough(config.mode == "passthrough");
 
         // Bring up the socket server first so its bind-time check cleanly
         // rejects a second Falco trying to share the same socket *before*

--- a/plugins/coding-agents-plugin/src/lib.rs
+++ b/plugins/coding-agents-plugin/src/lib.rs
@@ -106,6 +106,7 @@ impl Plugin for CodingAgentPlugin {
             bounded(DEFAULT_QUEUE_CAPACITY);
         let broker = Arc::new(Broker::new());
         broker.set_monitor_mode(config.mode == "monitor");
+        broker.set_passthrough(config.passthrough);
 
         // Bring up the socket server first so its bind-time check cleanly
         // rejects a second Falco trying to share the same socket *before*

--- a/plugins/coding-agents-plugin/src/lib.rs
+++ b/plugins/coding-agents-plugin/src/lib.rs
@@ -107,6 +107,14 @@ impl Plugin for CodingAgentPlugin {
         let broker = Arc::new(Broker::new());
         broker.set_monitor_mode(config.mode == "monitor");
         broker.set_passthrough(config.passthrough);
+        if config.passthrough && config.mode == "monitor" {
+            log::warn!(
+                "passthrough=true and mode=monitor are both set; \
+                 passthrough takes precedence — all requests will be \
+                 allowed immediately without rule-eval wait, and \
+                 monitor's would-deny/would-ask log lines will not fire"
+            );
+        }
 
         // Bring up the socket server first so its bind-time check cleanly
         // rejects a second Falco trying to share the same socket *before*

--- a/plugins/coding-agents-plugin/src/socket_server.rs
+++ b/plugins/coding-agents-plugin/src/socket_server.rs
@@ -343,8 +343,18 @@ fn handle_connection(
     broker.register(correlation_id, wire_id, stream);
 
     if event_tx.try_send(event_data).is_err() {
-        log::warn!("event queue full, denying event {}", correlation_id);
-        broker.apply_deny(correlation_id, "event queue full".to_string());
+        if broker.is_passthrough() {
+            // In passthrough, register() already wrote Allow and did not
+            // insert into the pending map. apply_deny would be a no-op
+            // here and the "denying event" wording would be misleading.
+            log::warn!(
+                "event queue full, event {} dropped (passthrough already allowed)",
+                correlation_id
+            );
+        } else {
+            log::warn!("event queue full, denying event {}", correlation_id);
+            broker.apply_deny(correlation_id, "event queue full".to_string());
+        }
         return Ok(());
     }
 

--- a/tests/tests/e2e_passthrough.rs
+++ b/tests/tests/e2e_passthrough.rs
@@ -1,0 +1,81 @@
+use prempti_tests::e2e::E2eHarness;
+use prempti_tests::interceptor::assert_decision;
+
+macro_rules! require_falco {
+    () => {
+        match E2eHarness::start("passthrough") {
+            Some(harness) => harness,
+            None => {
+                eprintln!("SKIP: falco or plugin not available");
+                return;
+            }
+        }
+    };
+}
+
+fn cwd() -> &'static str {
+    if cfg!(windows) {
+        "C:/Users/test/project"
+    } else {
+        "/tmp/myproject"
+    }
+}
+
+// Passthrough short-circuits at register: every tool call resolves as
+// `allow` immediately, without waiting for rule evaluation. From the
+// interceptor's POV the verdict is indistinguishable from monitor's
+// force-allow; the unique broker behavior (no pending insert, no rule-eval
+// wait) is covered by the unit tests in `plugins/coding-agents-plugin/src/
+// broker.rs`. These tests just confirm the wire-level result.
+
+#[test]
+fn passthrough_rm_rf_allowed() {
+    let h = require_falco!();
+    let input = E2eHarness::make_input("Bash", r#"{"command":"rm -rf /"}"#, cwd(), "pt-rm");
+    let r = h.run_hook(&input);
+    assert_decision(&r, "allow");
+}
+
+#[test]
+fn passthrough_write_sensitive_allowed() {
+    let h = require_falco!();
+    let path = if cfg!(windows) {
+        "C:/Windows/system.ini"
+    } else {
+        "/etc/passwd"
+    };
+    let input = E2eHarness::make_input(
+        "Write",
+        &format!(r#"{{"file_path":"{}","content":"x"}}"#, path),
+        cwd(),
+        "pt-wsen",
+    );
+    let r = h.run_hook(&input);
+    assert_decision(&r, "allow");
+}
+
+#[test]
+fn passthrough_write_outside_cwd_allowed() {
+    let h = require_falco!();
+    let path = if cfg!(windows) {
+        "C:/Users/other/file.txt"
+    } else {
+        "/home/other/file.txt"
+    };
+    let input = E2eHarness::make_input(
+        "Write",
+        &format!(r#"{{"file_path":"{}","content":"x"}}"#, path),
+        cwd(),
+        "pt-wout",
+    );
+    let r = h.run_hook(&input);
+    assert_decision(&r, "allow");
+}
+
+#[test]
+fn passthrough_safe_command_allowed() {
+    let h = require_falco!();
+    let input = E2eHarness::make_input("Bash", r#"{"command":"ls -la"}"#, cwd(), "pt-ls");
+    let r = h.run_hook(&input);
+    assert_decision(&r, "allow");
+}

--- a/tools/premptictl/src/main.rs
+++ b/tools/premptictl/src/main.rs
@@ -87,17 +87,14 @@ fn mode_get(prefix: &PathBuf) {
     println!("guardrails");
 }
 
-/// Parse the plugin config YAML for `mode` and `passthrough`. Returns
-/// `None` when the file is missing or unreadable so the caller can print
-/// "unknown" without bailing the whole status command.
+/// Parse the plugin config YAML for `mode`. Returns `None` when the file
+/// is missing or unreadable so the caller can print "unknown" without
+/// bailing the whole status command.
 ///
-/// Defaults match the plugin's serde defaults: `mode = "guardrails"` and
-/// `passthrough = false` when the keys are absent. `passthrough` accepts
-/// any truthy YAML scalar (`true`, `yes`, `on`, `1`, case-insensitive;
-/// optional surrounding quotes are tolerated for ergonomics).
-fn parse_plugin_config_summary(data: &str) -> (String, bool) {
+/// Default matches the plugin's serde default: `mode = "guardrails"` when
+/// the key is absent.
+fn parse_plugin_config_summary(data: &str) -> String {
     let mut mode = String::from("guardrails");
-    let mut passthrough = false;
     for line in data.lines() {
         let trimmed = line.trim();
         if let Some(rest) = trimmed.strip_prefix("mode:") {
@@ -105,42 +102,33 @@ fn parse_plugin_config_summary(data: &str) -> (String, bool) {
             if !value.is_empty() {
                 mode = value.trim_matches(|c| c == '"' || c == '\'').to_string();
             }
-        } else if let Some(rest) = trimmed.strip_prefix("passthrough:") {
-            let v = rest.trim().trim_matches(|c| c == '"' || c == '\'');
-            passthrough = v.eq_ignore_ascii_case("1")
-                || v.eq_ignore_ascii_case("true")
-                || v.eq_ignore_ascii_case("yes")
-                || v.eq_ignore_ascii_case("on");
         }
     }
-    (mode, passthrough)
+    mode
 }
 
-fn read_plugin_config_summary(prefix: &Path) -> Option<(String, bool)> {
+fn read_plugin_config_summary(prefix: &Path) -> Option<String> {
     let path = plugin_config_path(&prefix.to_path_buf());
     let data = fs::read_to_string(&path).ok()?;
     Some(parse_plugin_config_summary(&data))
 }
 
-/// Print the configured mode and passthrough state. Called by every platform's
-/// `service_status` so operators can tell at a glance whether enforcement has
-/// been altered.
+/// Print the configured mode. Called by every platform's `service_status`
+/// so operators can tell at a glance whether enforcement has been altered.
+/// `passthrough` is annotated as Experimental wherever it appears.
 fn print_plugin_config_summary(prefix: &Path) {
     match read_plugin_config_summary(prefix) {
-        Some((mode, passthrough)) => {
+        Some(mode) if mode == "passthrough" => {
+            println!(
+                "Mode: passthrough (Experimental — enforcement disabled; \
+                 tool calls allowed immediately)"
+            );
+        }
+        Some(mode) => {
             println!("Mode: {mode}");
-            if passthrough {
-                println!(
-                    "Passthrough: enabled (Experimental — enforcement disabled; \
-                     tool calls allowed immediately)"
-                );
-            } else {
-                println!("Passthrough: disabled   (Experimental)");
-            }
         }
         None => {
             println!("Mode: unknown");
-            println!("Passthrough: unknown");
             println!("  (plugin config not readable)");
         }
     }
@@ -177,8 +165,8 @@ fn rewrite_mode_in_yaml(data: &str, mode: &str) -> Option<String> {
 }
 
 fn mode_set(prefix: &PathBuf, mode: &str) {
-    if mode != "guardrails" && mode != "monitor" {
-        eprintln!("error: mode must be 'guardrails' or 'monitor'");
+    if mode != "guardrails" && mode != "monitor" && mode != "passthrough" {
+        eprintln!("error: mode must be 'guardrails', 'monitor', or 'passthrough'");
         process::exit(1);
     }
 
@@ -1692,29 +1680,29 @@ mod plugin_config_summary_tests {
     use std::path::Path;
 
     #[test]
-    fn defaults_when_passthrough_absent() {
-        let yaml = "init_config:\n  mode: guardrails\n";
-        let (mode, passthrough) = parse_plugin_config_summary(yaml);
-        assert_eq!(mode, "guardrails");
-        assert!(!passthrough);
+    fn defaults_to_guardrails_when_mode_absent() {
+        let yaml = "init_config:\n  socket_path: /tmp/x\n";
+        assert_eq!(parse_plugin_config_summary(yaml), "guardrails");
     }
 
     #[test]
-    fn monitor_with_passthrough_true() {
-        let yaml = "init_config:\n  mode: monitor\n  passthrough: true\n";
-        let (mode, passthrough) = parse_plugin_config_summary(yaml);
-        assert_eq!(mode, "monitor");
-        assert!(passthrough);
+    fn parses_monitor_mode() {
+        let yaml = "init_config:\n  mode: monitor\n";
+        assert_eq!(parse_plugin_config_summary(yaml), "monitor");
     }
 
     #[test]
-    fn monitor_with_passthrough_quoted_one() {
-        // Users may quote scalars; "1" should still parse as truthy so the
-        // status output matches what the plugin's serde deserializer accepts.
-        let yaml = "init_config:\n  mode: monitor\n  passthrough: \"1\"\n";
-        let (mode, passthrough) = parse_plugin_config_summary(yaml);
-        assert_eq!(mode, "monitor");
-        assert!(passthrough);
+    fn parses_passthrough_mode() {
+        let yaml = "init_config:\n  mode: passthrough\n";
+        assert_eq!(parse_plugin_config_summary(yaml), "passthrough");
+    }
+
+    #[test]
+    fn tolerates_quoted_scalar() {
+        // Users may quote scalars; quotes are stripped so the value matches
+        // what the plugin's serde deserializer accepts.
+        let yaml = "init_config:\n  mode: \"monitor\"\n";
+        assert_eq!(parse_plugin_config_summary(yaml), "monitor");
     }
 
     #[test]
@@ -1739,9 +1727,11 @@ fn print_usage() {
     eprintln!("  hook remove      Remove the interceptor hook from Claude Code");
     eprintln!("  hook status      Check if the hook is registered");
     eprintln!();
-    eprintln!("  mode             Show current operational mode");
-    eprintln!("  mode guardrails  Switch to guardrails mode (deny/ask enforced)");
-    eprintln!("  mode monitor     Switch to monitor mode (all verdicts allow, alerts logged)");
+    eprintln!("  mode              Show current operational mode");
+    eprintln!("  mode guardrails   Switch to guardrails mode (deny/ask enforced)");
+    eprintln!("  mode monitor      Switch to monitor mode (all verdicts allow, alerts logged)");
+    eprintln!("  mode passthrough  Switch to passthrough mode (Experimental, embedding-only:");
+    eprintln!("                    instant allow, no rule-eval wait; events still enqueued)");
     eprintln!();
     eprintln!("  start            Start the service");
     eprintln!("  stop             Stop the service");

--- a/tools/premptictl/src/main.rs
+++ b/tools/premptictl/src/main.rs
@@ -87,6 +87,65 @@ fn mode_get(prefix: &PathBuf) {
     println!("guardrails");
 }
 
+/// Parse the plugin config YAML for `mode` and `passthrough`. Returns
+/// `None` when the file is missing or unreadable so the caller can print
+/// "unknown" without bailing the whole status command.
+///
+/// Defaults match the plugin's serde defaults: `mode = "guardrails"` and
+/// `passthrough = false` when the keys are absent. `passthrough` accepts
+/// any truthy YAML scalar (`true`, `yes`, `on`, `1`, case-insensitive;
+/// optional surrounding quotes are tolerated for ergonomics).
+fn parse_plugin_config_summary(data: &str) -> (String, bool) {
+    let mut mode = String::from("guardrails");
+    let mut passthrough = false;
+    for line in data.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("mode:") {
+            let value = rest.trim();
+            if !value.is_empty() {
+                mode = value.trim_matches(|c| c == '"' || c == '\'').to_string();
+            }
+        } else if let Some(rest) = trimmed.strip_prefix("passthrough:") {
+            let v = rest.trim().trim_matches(|c| c == '"' || c == '\'');
+            passthrough = v.eq_ignore_ascii_case("1")
+                || v.eq_ignore_ascii_case("true")
+                || v.eq_ignore_ascii_case("yes")
+                || v.eq_ignore_ascii_case("on");
+        }
+    }
+    (mode, passthrough)
+}
+
+fn read_plugin_config_summary(prefix: &Path) -> Option<(String, bool)> {
+    let path = plugin_config_path(&prefix.to_path_buf());
+    let data = fs::read_to_string(&path).ok()?;
+    Some(parse_plugin_config_summary(&data))
+}
+
+/// Print the configured mode and passthrough state. Called by every platform's
+/// `service_status` so operators can tell at a glance whether enforcement has
+/// been altered.
+fn print_plugin_config_summary(prefix: &Path) {
+    match read_plugin_config_summary(prefix) {
+        Some((mode, passthrough)) => {
+            println!("Mode: {mode}");
+            if passthrough {
+                println!(
+                    "Passthrough: enabled (Experimental — enforcement disabled; \
+                     tool calls allowed immediately)"
+                );
+            } else {
+                println!("Passthrough: disabled   (Experimental)");
+            }
+        }
+        None => {
+            println!("Mode: unknown");
+            println!("Passthrough: unknown");
+            println!("  (plugin config not readable)");
+        }
+    }
+}
+
 /// Rewrite the `mode:` line in a plugin-config YAML, preserving indentation
 /// and comments. Returns `None` if no `mode:` line is found.
 fn rewrite_mode_in_yaml(data: &str, mode: &str) -> Option<String> {
@@ -288,6 +347,7 @@ fn service_status() {
     let _ = Command::new("systemctl")
         .args(["--user", "status", SERVICE_NAME, "--no-pager"])
         .status();
+    print_plugin_config_summary(&default_prefix());
 }
 
 #[cfg(target_os = "macos")]
@@ -426,6 +486,7 @@ fn service_status() {
     } else {
         println!("Service not running.");
     }
+    print_plugin_config_summary(&default_prefix());
 }
 
 // ---------------------------------------------------------------------------
@@ -824,6 +885,7 @@ fn service_status() {
             println!("Auto-start: disabled.");
         }
     }
+    print_plugin_config_summary(&prefix);
 }
 
 // ---------------------------------------------------------------------------
@@ -1621,6 +1683,45 @@ mod mode_tests {
         let yaml = "mode: guardrails\nother: thing\n";
         let out = rewrite_mode_in_yaml(yaml, "monitor").unwrap();
         assert!(out.contains("mode: monitor\n"));
+    }
+}
+
+#[cfg(test)]
+mod plugin_config_summary_tests {
+    use super::{parse_plugin_config_summary, read_plugin_config_summary};
+    use std::path::Path;
+
+    #[test]
+    fn defaults_when_passthrough_absent() {
+        let yaml = "init_config:\n  mode: guardrails\n";
+        let (mode, passthrough) = parse_plugin_config_summary(yaml);
+        assert_eq!(mode, "guardrails");
+        assert!(!passthrough);
+    }
+
+    #[test]
+    fn monitor_with_passthrough_true() {
+        let yaml = "init_config:\n  mode: monitor\n  passthrough: true\n";
+        let (mode, passthrough) = parse_plugin_config_summary(yaml);
+        assert_eq!(mode, "monitor");
+        assert!(passthrough);
+    }
+
+    #[test]
+    fn monitor_with_passthrough_quoted_one() {
+        // Users may quote scalars; "1" should still parse as truthy so the
+        // status output matches what the plugin's serde deserializer accepts.
+        let yaml = "init_config:\n  mode: monitor\n  passthrough: \"1\"\n";
+        let (mode, passthrough) = parse_plugin_config_summary(yaml);
+        assert_eq!(mode, "monitor");
+        assert!(passthrough);
+    }
+
+    #[test]
+    fn missing_file_returns_none() {
+        // The caller prints "unknown" when None.
+        let prefix = Path::new("/tmp/premptictl-tests-no-such-prefix-xyz");
+        assert!(read_plugin_config_summary(prefix).is_none());
     }
 }
 

--- a/tools/premptictl/src/main.rs
+++ b/tools/premptictl/src/main.rs
@@ -1672,6 +1672,17 @@ mod mode_tests {
         let out = rewrite_mode_in_yaml(yaml, "monitor").unwrap();
         assert!(out.contains("mode: monitor\n"));
     }
+
+    #[test]
+    fn rewrites_to_passthrough() {
+        // `passthrough` is the third accepted mode value; round-trip it both
+        // ways to confirm the rewriter is mode-string agnostic.
+        let yaml = "init_config:\n  mode: guardrails\n  http_port: 2802\n";
+        let out = rewrite_mode_in_yaml(yaml, "passthrough").unwrap();
+        assert!(out.contains("  mode: passthrough\n"), "got: {out}");
+        let back = rewrite_mode_in_yaml(&out, "guardrails").unwrap();
+        assert!(back.contains("  mode: guardrails\n"), "got: {back}");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area CI

/area ctl

> /area documentation

> /area installer

/area interceptor

/area plugin

> /area rules

> /area skills

> /area supervisor

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Adds two opt-in runtime controls for embedding Prempti inside a host
agent (e.g. an existing security agent with its own alert pipeline)
where blocking on the broker or on rule evaluation is undesirable.
Both controls default off — the standalone install posture is unchanged.

- **`PREMPTI_FAIL_OPEN`** (hook): when set to `1`/`true`/`yes`/`on`,
  broker communication failures (socket unavailable, timeout,
  malformed response, etc.) resolve as **allow** instead of deny.
  Default remains fail-closed.
- **`mode: passthrough`** (plugin, Experimental): a third value of
  `init_config.mode`, alongside `guardrails` (default) and `monitor`.
  When active, all interceptor requests are resolved as `allow`
  immediately at register, without waiting for rule evaluation. Events
  are still enqueued for Falco so observability via `http_output` /
  `falco.log` is preserved. Distinct from `mode: monitor`, which waits
  for rule evaluation synchronously and then forces an allow.

Additional changes that come with the new knobs:

- New `env_bool` helper for boolean Prempti env vars (accepts
  `1`/`true`/`yes`/`on`, case- and whitespace-tolerant). Avoids the
  `NO_COLOR` "any non-empty = true" footgun for a security-sensitive
  flag.
- `premptictl status` now surfaces the configured `mode` so operators
  can tell at a glance whether enforcement has been altered.
  `passthrough` is annotated as Experimental wherever it appears.
  Cross-platform; no new ctl command. `premptictl mode passthrough`
  accepts the new value, same restart cycle as the other modes.
- Fixes a misleading log line in `socket_server.rs` when the event
  queue is full under passthrough (the request has already been
  allowed; `apply_deny` was a silent no-op).
- Docs: `CLAUDE.md`, `configs/README.md`, sample yaml, and rustdoc
  cover the experimental passthrough mode. Top-level README
  intentionally untouched.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

## Test plan

- [x] `cargo test` passes for the hook crate (10 tests incl. 5 new
  `env_bool` cases)
- [x] `cargo test -p coding-agents-plugin` passes (65 tests incl. 2
  new broker passthrough cases)
- [x] `cargo test -p premptictl` passes (5 `plugin_config_summary`
  cases + 7 `mode_tests` cases including round-trip to `passthrough`)
- [x] `cargo test --test e2e_passthrough` passes (4 scenarios mirror
  `e2e_monitor.rs`)
- [x] `cargo build` succeeds for hook, plugin, and `premptictl`
- [ ] Manual smoke: stop the broker, run a tool call with
  `PREMPTI_FAIL_OPEN=1` → tool call allowed; without the var → denied
- [ ] Manual smoke: `premptictl mode passthrough` then start the
  service → `premptictl status` shows
  `Mode: passthrough (Experimental — enforcement disabled; ...)`
  and tool calls resolve immediately
