### PR TITLE
rules: add MITRE ATLAS / ATT&CK mappings to the unmapped deny/ask rules

### DIFF
--- a/rules/default/coding_agents_rules.yaml
+++ b/rules/default/coding_agents_rules.yaml
@@ -228,7 +228,7 @@
     Falco blocked reading %tool.real_file_path because it is a sensitive path
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1083_file_and_directory_discovery]
 
 - rule: Deny writing to sensitive paths
   desc: >
@@ -1135,7 +1135,7 @@
     Falco blocked a Bash command referencing a credential path or secret token (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1552_unsecured_credentials]
 
 - rule: Deny credential file access via Read tool
   desc: >
@@ -1151,7 +1151,7 @@
     Falco blocked the Read tool accessing a credential file at %tool.real_file_path
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1552_unsecured_credentials]
 
 - rule: Deny destructive system commands
   desc: >
@@ -1165,7 +1165,7 @@
     Falco blocked a destructive system command (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1485_data_destruction]
 
 - rule: Ask before potentially destructive shell commands
   desc: >
@@ -1181,7 +1181,7 @@
     Falco requires confirmation before a potentially destructive shell command (%tool.input_command)
   priority: WARNING
   source: coding_agent
-  tags: [coding_agent_ask]
+  tags: [coding_agent_ask, mitre_t1485_data_destruction]
 
 - rule: Ask before container privilege escalation or host breakout
   desc: >
@@ -1215,7 +1215,7 @@
     Falco blocked piping content to a shell interpreter (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1059_command_and_scripting_interpreter, mitre_t1105_ingress_tool_transfer]
 
 - rule: Deny encoded payload execution
   desc: >
@@ -1227,7 +1227,7 @@
     Falco blocked execution of a potentially encoded or inline-interpreted payload (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1027_obfuscated_files_or_information, mitre_t1140_deobfuscate_decode_files_or_information]
 
 - rule: Deny curl wget exfiltration
   desc: >
@@ -1239,7 +1239,7 @@
     Falco blocked a potential data exfiltration command via curl or wget (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, AML.T0025_exfiltration_via_cyber_means, mitre_t1567_exfiltration_over_web_service]
 
 - rule: Ask before writing to tmp staging paths
   desc: >
@@ -1258,7 +1258,7 @@
     Falco requires confirmation before writing to the staging path %tool.real_file_path
   priority: WARNING
   source: coding_agent
-  tags: [coding_agent_ask]
+  tags: [coding_agent_ask, mitre_t1074_data_staged]
 
 - rule: Deny reverse shell via Bash
   desc: >
@@ -1270,7 +1270,7 @@
     Falco blocked a reverse shell command (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1059_command_and_scripting_interpreter, mitre_t1571_non_standard_port]
 
 - rule: Deny cloud metadata service access via Bash
   desc: >
@@ -1283,7 +1283,7 @@
     Falco blocked access to a cloud metadata service (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1552.005_cloud_instance_metadata_api]
 
 - rule: Deny credential directory archive via Bash
   desc: >
@@ -1295,7 +1295,7 @@
     Falco blocked archiving a credential directory (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1560_archive_collected_data, mitre_t1552_unsecured_credentials]
 
 - rule: Deny SSH reverse tunnel and SOCKS proxy
   desc: >
@@ -1308,7 +1308,7 @@
     Falco blocked an SSH tunneling or proxy command (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1572_protocol_tunneling]
 
 - rule: Ask before cron and scheduled task manipulation
   desc: >
@@ -1321,7 +1321,7 @@
     Falco requires confirmation before modifying cron configuration (%tool.input_command)
   priority: WARNING
   source: coding_agent
-  tags: [coding_agent_ask]
+  tags: [coding_agent_ask, mitre_t1053_scheduled_task_job]
 
 - rule: Deny audit trail destruction
   desc: >
@@ -1334,7 +1334,7 @@
     Falco blocked a shell history wipe attempt (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1070_indicator_removal]
 
 - rule: Deny package publish
   desc: >
@@ -1347,7 +1347,7 @@
     Falco blocked a package publish command (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, AML.T0010_ml_supply_chain_compromise, mitre_t1195_supply_chain_compromise]
 
 - rule: Ask before modifying shell startup files
   desc: >
@@ -1363,7 +1363,7 @@
     Falco requires confirmation before modifying shell startup file %tool.real_file_path
   priority: WARNING
   source: coding_agent
-  tags: [coding_agent_ask]
+  tags: [coding_agent_ask, mitre_t1546.004_unix_shell_configuration_modification]
 
 - rule: Ask before writing agent instruction files outside working directory
   desc: >
@@ -1381,7 +1381,7 @@
     Falco requires confirmation before writing agent instruction file %tool.real_file_path outside working directory %agent.real_cwd
   priority: WARNING
   source: coding_agent
-  tags: [coding_agent_ask]
+  tags: [coding_agent_ask, AML.T0051_llm_prompt_injection]
 
 - rule: Deny cross-agent authentication file access
   desc: >
@@ -1394,7 +1394,7 @@
     Falco blocked %agent.name from reading another agent's authentication file %tool.real_file_path
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, mitre_t1552_unsecured_credentials]
 
 - rule: Deny MCP server or skill install from untrusted host
   desc: >
@@ -1407,7 +1407,7 @@
     Falco blocked installing a package or skill from an untrusted host (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, AML.T0010_ml_supply_chain_compromise, AML.T0048_llm_plugin_compromise]
 
 - rule: Deny MCP server execution from temporary directory
   desc: >
@@ -1420,7 +1420,7 @@
     Falco blocked executing a potential MCP server from a temporary directory (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny]
+  tags: [coding_agent_deny, AML.T0048_llm_plugin_compromise]
 
 - rule: Ask before Glob with credential directory patterns
   desc: >
@@ -1434,7 +1434,7 @@
     Falco requires confirmation before globbing with a credential-targeting pattern (%tool.input)
   priority: WARNING
   source: coding_agent
-  tags: [coding_agent_ask]
+  tags: [coding_agent_ask, mitre_t1552_unsecured_credentials]
 
 # ===========================================================================
 # Section 5 — MCP and skill content
@@ -1842,7 +1842,7 @@
     Falco requires confirmation before writing to Claude Code settings backups at %tool.real_file_path
   priority: WARNING
   source: coding_agent
-  tags: [coding_agent_ask, prempti_self_protection]
+  tags: [coding_agent_ask, prempti_self_protection, mitre_t1562.001_impair_defenses_disable_or_modify_tools]
 
 # ===========================================================================
 # Section 6 — Persistence vectors
@@ -2170,7 +2170,7 @@
     Falco blocked an agent invocation of the premptictl CLI (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny, prempti_self_protection]
+  tags: [coding_agent_deny, prempti_self_protection, mitre_t1562.001_impair_defenses_disable_or_modify_tools]
 
 - macro: is_service_stop_linux
   condition: >
@@ -2228,7 +2228,7 @@
     Falco blocked a platform service-stop command targeting Prempti (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny, prempti_self_protection]
+  tags: [coding_agent_deny, prempti_self_protection, mitre_t1562.001_impair_defenses_disable_or_modify_tools]
 
 - macro: is_prempti_install_path
   condition: >
@@ -2261,7 +2261,7 @@
     Falco blocked writing to %tool.real_file_path under the Prempti install prefix
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny, prempti_self_protection]
+  tags: [coding_agent_deny, prempti_self_protection, mitre_t1562.001_impair_defenses_disable_or_modify_tools]
 
 - rule: Deny writes to Claude Code settings file
   desc: >
@@ -2274,7 +2274,7 @@
     Falco blocked writing to Claude Code settings at %tool.real_file_path
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny, prempti_self_protection]
+  tags: [coding_agent_deny, prempti_self_protection, mitre_t1562.001_impair_defenses_disable_or_modify_tools]
 
 - rule: Deny writes to Claude Code policy limits file
   desc: >
@@ -2293,7 +2293,7 @@
     Falco blocked writing to Claude Code policy-limits.json at %tool.real_file_path
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny, prempti_self_protection]
+  tags: [coding_agent_deny, prempti_self_protection, mitre_t1562.001_impair_defenses_disable_or_modify_tools]
 
 - rule: Ask before reading Claude Code settings file
   desc: >
@@ -2306,4 +2306,4 @@
     Falco requires confirmation to read Claude Code settings at %tool.real_file_path
   priority: WARNING
   source: coding_agent
-  tags: [coding_agent_ask, prempti_self_protection]
+  tags: [coding_agent_ask, prempti_self_protection, mitre_t1562.001_impair_defenses_disable_or_modify_tools]

--- a/rules/default/coding_agents_rules.yaml
+++ b/rules/default/coding_agents_rules.yaml
@@ -228,7 +228,7 @@
     Falco blocked reading %tool.real_file_path because it is a sensitive path
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny, mitre_t1083_file_and_directory_discovery]
+  tags: [coding_agent_deny, mitre_t1552_unsecured_credentials]
 
 - rule: Deny writing to sensitive paths
   desc: >
@@ -1270,7 +1270,7 @@
     Falco blocked a reverse shell command (%tool.input_command)
   priority: CRITICAL
   source: coding_agent
-  tags: [coding_agent_deny, mitre_t1059_command_and_scripting_interpreter, mitre_t1571_non_standard_port]
+  tags: [coding_agent_deny, mitre_t1059_command_and_scripting_interpreter]
 
 - rule: Deny cloud metadata service access via Bash
   desc: >


### PR DESCRIPTION
## Summary

The default ruleset already tags some rules with framework techniques (sandbox-disable, container-escape carry `AML.T0051_llm_prompt_injection`, `mitre_t1611_escape_to_host`, etc.), but the credential-access, exfiltration, persistence, MCP supply-chain, and self-protection rules were untagged. This completes that coverage: **29 rules** get ATLAS / ATT&CK tags using the **existing tag convention** (`AML.Txxxx_name` / `mitre_txxxx_name`).

Mappings are drawn from [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules), whose rules are maintained with MITRE ATLAS / ATT&CK / OWASP mappings.

## Scope & safety

- **Tags-only, additive.** No condition, macro, field, output, or verdict-tag change. Every modified rule keeps its `coding_agent_deny` / `coding_agent_ask` (and `prempti_self_protection`) tag; framework tags are appended.
- Rule count unchanged (60). YAML validated. Tags are free-form strings in Falco, so this cannot affect rule loading or verdict evaluation. The e2e suite uses its own inline rules and does not assert on this file's tags.

## Examples

`Deny credential file access via Bash` → `+ mitre_t1552_unsecured_credentials`
`Deny curl wget exfiltration` → `+ AML.T0025_exfiltration_via_cyber_means, mitre_t1567_exfiltration_over_web_service`
`Deny cloud metadata service access via Bash` → `+ mitre_t1552.005_cloud_instance_metadata_api`
Self-protection cluster → `+ mitre_t1562.001_impair_defenses_disable_or_modify_tools`

## Intentionally left unmapped

`Ask before writing outside working directory` and `Deny writing to sensitive paths` are boundary controls without a single unambiguous technique — left for maintainer discretion rather than forcing a weak mapping.

## Optional follow-up

Prempti uses no OWASP tags today; happy to add OWASP Agentic Top-10 mappings as a second dimension under whatever tag convention you prefer.