### PR TITLE
refine codex support

### DIFF
--- a/docs/hooks/codex/SPEC.md
+++ b/docs/hooks/codex/SPEC.md
@@ -261,7 +261,7 @@ Recommended:
 premptictl hook add codex
 ```
 
-This writes `~/.codex/hooks.json` registering the interceptor for both `PreToolUse` and `PermissionRequest` with matcher `.*` (regex; matches every tool name) and a 30-second timeout. It also records the Codex opt-in marker under the Prempti install prefix, so the supervisor re-asserts the JSON hook on service start and removes it on service stop. Remove with `premptictl hook remove codex`; check state with `premptictl hook status codex`.
+This writes `~/.codex/hooks.json` registering the interceptor for both `PreToolUse` and `PermissionRequest` with matcher `.*` (regex; matches every tool name) and a 30-second timeout. It also records the Codex opt-in marker under the Prempti install prefix, so the supervisor re-asserts the JSON hook on service start and removes it on service stop. Remove with `premptictl hook remove codex`; check state with `premptictl hook status codex` (reports the `hooks.json` path, the opt-in marker state, and both event mounts — warning if only one is registered).
 
 The hand-rolled equivalent is documented in [`hooks/codex/README.md`](../../../hooks/codex/README.md). Codex also accepts an inline `[hooks]` block in `~/.codex/config.toml`; both layers are loaded together.
 

--- a/hooks/codex/README.md
+++ b/hooks/codex/README.md
@@ -99,7 +99,7 @@ Register the interceptor with:
 premptictl hook add codex
 ```
 
-This writes a `~/.codex/hooks.json` file that mounts the packaged `codex-interceptor` binary on both `PreToolUse` and `PermissionRequest` (matcher `.*`, 30s timeout). The file is self-contained — your `~/.codex/config.toml` is not touched. Remove with `premptictl hook remove codex`; status with `premptictl hook status codex`.
+This writes a `~/.codex/hooks.json` file that mounts the packaged `codex-interceptor` binary on both `PreToolUse` and `PermissionRequest` (matcher `.*`, 30s timeout). The file is self-contained — your `~/.codex/config.toml` is not touched. Remove with `premptictl hook remove codex`; check state with `premptictl hook status codex` — which reports the `hooks.json` path, whether the supervisor is managing the hook, and both event mounts, warning if only one of `PreToolUse` / `PermissionRequest` is registered.
 
 The hook remains opt-in. Once enabled, the Prempti supervisor manages its lifecycle alongside the Claude Code hook: it re-asserts the JSON hook on service start and removes it on service stop so Codex does not fail closed against a dead broker. The opt-in marker remains until `premptictl hook remove codex`.
 
@@ -127,6 +127,12 @@ If you'd rather hand-roll the config — for example to bind it to a specific ma
 ```
 
 (Codex also accepts an inline `[hooks]` block in `~/.codex/config.toml`; both layers are loaded.)
+
+## Session names in `premptictl logs`
+
+Codex never sends a human-readable session name in the hook payload — only `session_id`. The name you set with Codex's `/rename` (and the auto-generated name Codex assigns) live in `~/.codex/session_index.jsonl`, appended one `{"id": …, "thread_name": …}` line per change (last wins). `premptictl logs` resolves that file — its path derived from the hook's `transcript_path` (the rollout file under `<codex_home>/sessions/…`, so a custom `CODEX_HOME` is handled automatically) — and renders the `thread_name` in the session banner and per-line label, so a `/rename` shows up live.
+
+If the index is absent or its (undocumented, version-specific) format changes, resolution falls back to the short session id. It is display-only: rule matching always uses the stable `agent.session_id`.
 
 ## Configuration
 

--- a/tools/premptictl/README.md
+++ b/tools/premptictl/README.md
@@ -15,9 +15,18 @@ Binary: `target/release/premptictl`
 ### Hook Management
 
 ```bash
-premptictl hook add       # Register interceptor in Claude Code settings.json
-premptictl hook remove    # Remove interceptor from Claude Code settings.json
-premptictl hook status    # Check if the hook is registered
+# Claude Code (~/.claude/settings.json)
+premptictl hook add        # Register the interceptor on PreToolUse
+premptictl hook remove     # Remove the interceptor
+premptictl hook status     # Report what's registered: the settings file, the
+                           # interceptor path and event, and any stale, foreign,
+                           # duplicate, or missing-binary condition
+
+# Codex CLI (~/.codex/hooks.json, experimental)
+premptictl hook add codex      # Register on PreToolUse + PermissionRequest
+premptictl hook remove codex   # Remove the interceptor
+premptictl hook status codex   # Report path, supervisor-managed marker, and both
+                               # event mounts; warns if only one event is hooked
 ```
 
 ### Mode Switching
@@ -82,6 +91,8 @@ premptictl logs --err [flags]   # Same, but against the stderr log
 ```
 
 `logs` defaults to a snapshot-and-exit (like `kubectl logs` / `docker logs`) of the **last 100 lines**. Pass `-f` / `--follow` to stream new output afterwards. `--tail=N` overrides the line count (use a large value if you want the entire file). The `--err` flag targets `falco.err` instead of `falco.log`.
+
+The pretty renderer shows a friendly **session name** in the banner and per-line label when it can resolve one: for Claude Code it reads the transcript's `/rename` title (falling back to the first user message); for Codex it reads `~/.codex/session_index.jsonl` (the `thread_name`, which reflects Codex's `/rename` as well as its auto-generated names). It falls back to the short session id when no name is available — name resolution is display-only and never affects policy.
 
 ## Service Lifecycle
 

--- a/tools/premptictl/src/daemon/control.rs
+++ b/tools/premptictl/src/daemon/control.rs
@@ -271,15 +271,26 @@ mod tests {
         dir
     }
 
-    /// Try to bind in `dir`, skipping the test (and printing why) if the
-    /// environment refuses AF_UNIX bind there. Sandboxed CI runners
-    /// (Landlock, restricted seccomp, certain container `/tmp` policies)
-    /// can block bind with EPERM even though the path is writable.
+    /// Whether a `bind` failure means the *environment* can't host the test
+    /// socket (so the test should skip, not fail) rather than a product bug.
+    /// Two cases: sandboxed CI runners (Landlock / seccomp / container `/tmp`
+    /// policy) reject bind with EPERM; and on macOS a deep `std::env::temp_dir`
+    /// path can overflow the ~104-byte `sun_path` limit, which std reports as
+    /// `InvalidInput` ("path must be shorter than SUN_LEN").
+    fn bind_unavailable(e: &io::Error) -> bool {
+        matches!(
+            e.kind(),
+            io::ErrorKind::PermissionDenied | io::ErrorKind::InvalidInput
+        )
+    }
+
+    /// Try to bind in `dir`, skipping the test (and printing why) when the
+    /// environment can't host the socket there (see `bind_unavailable`).
     fn try_bind_or_skip(dir: &Path, label: &str) -> Option<(UnixListener, PathBuf)> {
         let sock = dir.join("supervisor.sock");
         match bind(&sock) {
             Ok(l) => Some((l, sock)),
-            Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
+            Err(e) if bind_unavailable(&e) => {
                 eprintln!(
                     "[skip {label}] cannot bind AF_UNIX in {}: {e}",
                     dir.display()
@@ -333,7 +344,7 @@ mod tests {
         std::fs::create_dir_all(&parent).unwrap();
         let listener = match bind(&sock) {
             Ok(l) => l,
-            Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
+            Err(e) if bind_unavailable(&e) => {
                 eprintln!(
                     "[skip bind_chmods_socket_and_run_dir] cannot bind AF_UNIX in {}: {e}",
                     parent.display()

--- a/tools/premptictl/src/daemon/rotate.rs
+++ b/tools/premptictl/src/daemon/rotate.rs
@@ -64,7 +64,8 @@ mod tests {
     use std::io::Write;
 
     fn tmpdir(label: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("prempti-rotate-{}-{}", std::process::id(), label));
+        let dir =
+            std::env::temp_dir().join(format!("prempti-rotate-{}-{}", std::process::id(), label));
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
         dir

--- a/tools/premptictl/src/hook.rs
+++ b/tools/premptictl/src/hook.rs
@@ -55,6 +55,58 @@ fn is_owned_interceptor_command(cmd: &str, expected: &str) -> bool {
     SUFFIXES.iter().any(|s| cmd.ends_with(s))
 }
 
+/// Expand a leading `$HOME` / `${HOME}` (the form we write for the default
+/// prefix) so the interceptor binary can be stat-ed for existence. Custom-
+/// prefix and Windows commands are already absolute and pass through.
+pub(crate) fn expand_home(cmd: &str) -> String {
+    #[cfg(unix)]
+    let home = env::var("HOME").unwrap_or_default();
+    #[cfg(windows)]
+    let home = env::var("USERPROFILE").unwrap_or_default();
+    if home.is_empty() {
+        return cmd.to_string();
+    }
+    if let Some(rest) = cmd.strip_prefix("${HOME}") {
+        format!("{home}{rest}")
+    } else if let Some(rest) = cmd.strip_prefix("$HOME") {
+        format!("{home}{rest}")
+    } else {
+        cmd.to_string()
+    }
+}
+
+/// Walk `hooks.PreToolUse[*].hooks[*]` and split interceptor commands into
+/// `(owned, foreign)`: `owned` are Prempti's (exact match on `expected`, or a
+/// well-known path suffix), `foreign` merely contain the `claude-interceptor`
+/// substring (e.g. a user's own wrapper) and are reported but never touched.
+fn scan_pre_tool_use(settings: &serde_json::Value, expected: &str) -> (Vec<String>, Vec<String>) {
+    let mut owned = Vec::new();
+    let mut foreign = Vec::new();
+    let Some(groups) = settings
+        .get("hooks")
+        .and_then(|h| h.get("PreToolUse"))
+        .and_then(|p| p.as_array())
+    else {
+        return (owned, foreign);
+    };
+    for group in groups {
+        let Some(hooks) = group.get("hooks").and_then(|h| h.as_array()) else {
+            continue;
+        };
+        for h in hooks {
+            let Some(cmd) = h.get("command").and_then(|c| c.as_str()) else {
+                continue;
+            };
+            if is_owned_interceptor_command(cmd, expected) {
+                owned.push(cmd.to_string());
+            } else if cmd.contains("claude-interceptor") {
+                foreign.push(cmd.to_string());
+            }
+        }
+    }
+    (owned, foreign)
+}
+
 pub enum AddResult {
     Added(PathBuf),
     AlreadyRegistered,
@@ -67,12 +119,17 @@ pub enum RemoveResult {
 
 pub fn is_registered() -> bool {
     let path = claude_settings_path();
-    if !path.exists() {
+    let Ok(data) = fs::read_to_string(&path) else {
         return false;
+    };
+    match serde_json::from_str::<serde_json::Value>(&data) {
+        // "Registered" means *our* interceptor (owned), not merely the
+        // `claude-interceptor` substring inside some unrelated user hook.
+        Ok(settings) => !scan_pre_tool_use(&settings, "").0.is_empty(),
+        // Malformed settings: fall back to substring so we still treat the
+        // file as registered, keeping the restart re-add path fail-closed.
+        Err(_) => data.contains("claude-interceptor"),
     }
-    fs::read_to_string(&path)
-        .map(|data| data.contains("claude-interceptor"))
-        .unwrap_or(false)
 }
 
 pub fn add(prefix: &Path) -> Result<AddResult, String> {
@@ -230,17 +287,76 @@ pub fn cli_remove(prefix: &Path) {
     }
 }
 
-pub fn cli_status() {
+pub fn cli_status(prefix: &Path) {
     let path = claude_settings_path();
     if !path.exists() {
-        println!("Not registered (no settings file).");
+        println!(
+            "Claude Code hook: not registered (no settings file at {}).",
+            path.display()
+        );
         return;
     }
-    let data = fs::read_to_string(&path).unwrap_or_default();
-    if data.contains("claude-interceptor") {
-        println!("Registered.");
-    } else {
-        println!("Not registered.");
+    let data = match fs::read_to_string(&path) {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Claude Code hook: cannot read {} ({e}).", path.display());
+            return;
+        }
+    };
+    let settings: serde_json::Value = match serde_json::from_str(&data) {
+        Ok(v) => v,
+        Err(e) => {
+            let hint = if data.contains("claude-interceptor") {
+                " — an interceptor-like entry appears present but could not be verified"
+            } else {
+                ""
+            };
+            println!(
+                "Claude Code hook: {} is not valid JSON ({e}){hint}.",
+                path.display()
+            );
+            return;
+        }
+    };
+
+    let expected = interceptor_command(prefix);
+    let (owned, foreign) = scan_pre_tool_use(&settings, &expected);
+
+    if owned.is_empty() {
+        if foreign.is_empty() {
+            println!("Claude Code hook: not registered.");
+        } else {
+            println!(
+                "Claude Code hook: not registered by Prempti; found {} interceptor-like hook(s) left untouched:",
+                foreign.len()
+            );
+            for cmd in &foreign {
+                println!("    PreToolUse → {cmd}");
+            }
+        }
+        return;
+    }
+
+    println!("Claude Code hook: registered in {}", path.display());
+    for cmd in &owned {
+        let missing = if Path::new(&expand_home(cmd)).exists() {
+            ""
+        } else {
+            "  [interceptor binary not found at this path]"
+        };
+        println!("    PreToolUse → {cmd}{missing}");
+    }
+    if owned.iter().any(|c| c != &expected) {
+        println!("    note: a registered path differs from this install's prefix ({expected}).");
+    }
+    if owned.len() > 1 {
+        println!(
+            "    note: {} interceptor hooks registered — duplicates?",
+            owned.len()
+        );
+    }
+    for cmd in &foreign {
+        println!("    plus a non-Prempti interceptor-like hook (left untouched): {cmd}");
     }
 }
 
@@ -368,7 +484,11 @@ mod tests {
         let removed = strip_owned_hooks(&mut settings, "$HOME/.prempti/bin/claude-interceptor");
         assert!(removed);
         let groups = settings["hooks"]["PreToolUse"].as_array().unwrap();
-        assert_eq!(groups.len(), 1, "unrelated group should survive: {settings}");
+        assert_eq!(
+            groups.len(),
+            1,
+            "unrelated group should survive: {settings}"
+        );
         assert_eq!(groups[0]["matcher"].as_str().unwrap(), "Bash");
     }
 
@@ -386,5 +506,60 @@ mod tests {
         let removed = strip_owned_hooks(&mut settings, "$HOME/.prempti/bin/claude-interceptor");
         assert!(!removed);
         assert_eq!(settings, snapshot, "settings should be untouched");
+    }
+
+    #[test]
+    fn scan_classifies_owned_and_foreign() {
+        let settings = json!({
+            "hooks": {"PreToolUse": [{
+                "matcher": "",
+                "hooks": [
+                    {"type": "command", "command": "$HOME/.prempti/bin/claude-interceptor"},
+                    {"type": "command", "command": "python my-claude-interceptor.py"},
+                    {"type": "command", "command": "/opt/prempti/bin/claude-interceptor"}
+                ]
+            }]}
+        });
+        let (owned, foreign) =
+            scan_pre_tool_use(&settings, "$HOME/.prempti/bin/claude-interceptor");
+        assert_eq!(
+            owned.len(),
+            2,
+            "exact + suffix matches are owned: {owned:?}"
+        );
+        assert_eq!(foreign, vec!["python my-claude-interceptor.py".to_string()]);
+    }
+
+    #[test]
+    fn scan_empty_without_pre_tool_use() {
+        let (owned, foreign) = scan_pre_tool_use(&json!({}), "x");
+        assert!(owned.is_empty() && foreign.is_empty());
+    }
+
+    #[test]
+    fn expand_home_passthrough_for_absolute_paths() {
+        assert_eq!(
+            expand_home("/opt/x/bin/claude-interceptor"),
+            "/opt/x/bin/claude-interceptor"
+        );
+    }
+
+    #[test]
+    fn expand_home_expands_leading_home_token() {
+        #[cfg(unix)]
+        let home = std::env::var("HOME").unwrap_or_default();
+        #[cfg(windows)]
+        let home = std::env::var("USERPROFILE").unwrap_or_default();
+        if home.is_empty() {
+            return; // can't meaningfully test without a home dir
+        }
+        assert_eq!(
+            expand_home("$HOME/.prempti/bin/claude-interceptor"),
+            format!("{home}/.prempti/bin/claude-interceptor")
+        );
+        assert_eq!(
+            expand_home("${HOME}/.prempti/bin/claude-interceptor"),
+            format!("{home}/.prempti/bin/claude-interceptor")
+        );
     }
 }

--- a/tools/premptictl/src/hook_codex.rs
+++ b/tools/premptictl/src/hook_codex.rs
@@ -38,8 +38,7 @@ fn mark_enabled(prefix: &Path) -> Result<(), String> {
         fs::create_dir_all(parent)
             .map_err(|e| format!("error creating {}: {e}", parent.display()))?;
     }
-    fs::write(&marker, b"")
-        .map_err(|e| format!("error writing marker {}: {e}", marker.display()))
+    fs::write(&marker, b"").map_err(|e| format!("error writing marker {}: {e}", marker.display()))
 }
 
 fn mark_disabled(prefix: &Path) -> Result<(), String> {
@@ -121,6 +120,37 @@ fn is_owned_codex_interceptor_command(cmd: &str, expected: &str) -> bool {
     SUFFIXES.iter().any(|s| cmd.ends_with(s))
 }
 
+/// Owned interceptor commands registered under a single event
+/// (`hooks.<event>[*].hooks[*]`). Empty when the event isn't present or holds
+/// only foreign hooks.
+fn owned_commands_for_event(
+    settings: &serde_json::Value,
+    event: &str,
+    expected: &str,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    let Some(groups) = settings
+        .get("hooks")
+        .and_then(|h| h.get(event))
+        .and_then(|p| p.as_array())
+    else {
+        return out;
+    };
+    for group in groups {
+        let Some(hooks) = group.get("hooks").and_then(|h| h.as_array()) else {
+            continue;
+        };
+        for h in hooks {
+            if let Some(cmd) = h.get("command").and_then(|c| c.as_str()) {
+                if is_owned_codex_interceptor_command(cmd, expected) {
+                    out.push(cmd.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
 pub enum AddResult {
     Added(PathBuf),
     AlreadyRegistered,
@@ -129,23 +159,6 @@ pub enum AddResult {
 pub enum RemoveResult {
     Removed(PathBuf),
     NotFound,
-}
-
-/// Whether the Codex JSON hook is currently registered in `~/.codex/hooks.json`.
-/// Distinct from `is_enabled` (the marker that records user intent): the
-/// supervisor removes the JSON on service stop but keeps the marker, so
-/// across a stop/start window `is_registered` may be false even when
-/// `is_enabled` is true.
-pub fn is_registered() -> bool {
-    let path = codex_hooks_path();
-    if !path.exists() {
-        return false;
-    }
-    fs::read_to_string(&path)
-        .ok()
-        .and_then(|data| serde_json::from_str::<serde_json::Value>(&data).ok())
-        .map(|settings| has_owned_codex_interceptor_hook(&settings))
-        .unwrap_or(false)
 }
 
 pub fn add(prefix: &Path) -> Result<AddResult, String> {
@@ -219,32 +232,6 @@ fn ensure_event_hook(settings: &mut serde_json::Value, event: &str, hook_cmd: &s
     true
 }
 
-fn has_owned_codex_interceptor_hook(settings: &serde_json::Value) -> bool {
-    let Some(hooks) = settings.get("hooks").and_then(|h| h.as_object()) else {
-        return false;
-    };
-    for event in [PRE_TOOL_USE, PERMISSION_REQUEST] {
-        let Some(groups) = hooks.get(event).and_then(|p| p.as_array()) else {
-            continue;
-        };
-        for group in groups {
-            let Some(group_hooks) = group.get("hooks").and_then(|h| h.as_array()) else {
-                continue;
-            };
-            for hook in group_hooks {
-                if hook
-                    .get("command")
-                    .and_then(|c| c.as_str())
-                    .is_some_and(|c| is_owned_codex_interceptor_command(c, ""))
-                {
-                    return true;
-                }
-            }
-        }
-    }
-    false
-}
-
 pub fn remove(prefix: &Path) -> Result<RemoveResult, String> {
     let path = codex_hooks_path();
     if !path.exists() {
@@ -266,13 +253,9 @@ pub fn remove(prefix: &Path) -> Result<RemoveResult, String> {
     // If our removal emptied the whole file (no other hooks, no other
     // top-level keys), delete it rather than leaving behind a stub.
     // Otherwise rewrite the trimmed JSON.
-    let is_empty = settings
-        .as_object()
-        .map(|o| o.is_empty())
-        .unwrap_or(true);
+    let is_empty = settings.as_object().map(|o| o.is_empty()).unwrap_or(true);
     if is_empty {
-        fs::remove_file(&path)
-            .map_err(|e| format!("error removing {}: {e}", path.display()))?;
+        fs::remove_file(&path).map_err(|e| format!("error removing {}: {e}", path.display()))?;
     } else {
         let output = serde_json::to_string_pretty(&settings).unwrap();
         fs::write(&path, format!("{output}\n"))
@@ -295,7 +278,8 @@ fn strip_owned_hooks(settings: &mut serde_json::Value, expected: &str) -> bool {
     for event in &[PRE_TOOL_USE, PERMISSION_REQUEST] {
         if let Some(arr) = hooks.get_mut(*event).and_then(|p| p.as_array_mut()) {
             arr.retain_mut(|group| {
-                let Some(group_hooks) = group.get_mut("hooks").and_then(|h| h.as_array_mut()) else {
+                let Some(group_hooks) = group.get_mut("hooks").and_then(|h| h.as_array_mut())
+                else {
                     return true;
                 };
                 let before = group_hooks.len();
@@ -342,7 +326,9 @@ pub fn cli_add(prefix: &Path) {
             println!("Codex hook registered in {}", path.display());
             if let Err(e) = mark_enabled(prefix) {
                 eprintln!("warning: hook registered but enable marker failed: {e}");
-                eprintln!("         (the supervisor won't re-assert this hook across service restarts)");
+                eprintln!(
+                    "         (the supervisor won't re-assert this hook across service restarts)"
+                );
             }
             print_warning();
         }
@@ -383,17 +369,79 @@ pub fn cli_remove(prefix: &Path) {
 }
 
 pub fn cli_status(prefix: &Path) {
-    let registered = is_registered();
+    let path = codex_hooks_path();
     let enabled = is_enabled(prefix);
-    match (registered, enabled) {
-        (true, true) => println!("Codex hook: registered, supervisor-managed."),
-        (true, false) => println!(
-            "Codex hook: registered (no enable marker — supervisor will not re-assert across restarts)."
-        ),
-        (false, true) => println!(
-            "Codex hook: enabled marker present but JSON missing (expected briefly between supervisor stop and next start)."
-        ),
-        (false, false) => println!("Codex hook: not registered."),
+
+    if !path.exists() {
+        if enabled {
+            println!(
+                "Codex hook: enable marker present but {} is missing (expected briefly between supervisor stop and next start).",
+                path.display()
+            );
+        } else {
+            println!("Codex hook: not registered.");
+        }
+        return;
+    }
+
+    let settings: serde_json::Value = match fs::read_to_string(&path) {
+        Ok(data) => match serde_json::from_str(&data) {
+            Ok(v) => v,
+            Err(e) => {
+                println!("Codex hook: {} is not valid JSON ({e}).", path.display());
+                return;
+            }
+        },
+        Err(e) => {
+            println!("Codex hook: cannot read {} ({e}).", path.display());
+            return;
+        }
+    };
+
+    let expected = interceptor_command(prefix);
+    let pre = owned_commands_for_event(&settings, PRE_TOOL_USE, &expected);
+    let pr = owned_commands_for_event(&settings, PERMISSION_REQUEST, &expected);
+
+    if pre.is_empty() && pr.is_empty() {
+        println!(
+            "Codex hook: not registered (no Prempti interceptor in {}).",
+            path.display()
+        );
+        return;
+    }
+
+    let marker = if enabled {
+        "supervisor-managed"
+    } else {
+        "no enable marker — supervisor will not re-assert across restarts"
+    };
+    println!("Codex hook: registered in {} ({marker}).", path.display());
+
+    for (event, cmds) in [(PRE_TOOL_USE, &pre), (PERMISSION_REQUEST, &pr)] {
+        for cmd in cmds {
+            let missing = if Path::new(&crate::hook::expand_home(cmd)).exists() {
+                ""
+            } else {
+                "  [interceptor binary not found at this path]"
+            };
+            println!("    {event} → {cmd}{missing}");
+        }
+    }
+
+    // Codex routes PreToolUse and PermissionRequest to the interceptor; a
+    // half-registered state silently lets one class of calls bypass policy.
+    if pre.is_empty() || pr.is_empty() {
+        let missing_event = if pre.is_empty() {
+            PRE_TOOL_USE
+        } else {
+            PERMISSION_REQUEST
+        };
+        println!(
+            "    WARNING: only one event is hooked — {missing_event} is missing. Run `premptictl hook add codex` to repair."
+        );
+    }
+    if pre.iter().chain(pr.iter()).any(|c| c != &expected) {
+        println!("    note: a registered path differs from this install's prefix ({expected}).");
     }
 }
 
@@ -453,8 +501,16 @@ mod tests {
     #[test]
     fn add_into_empty_settings_registers_both_events() {
         let mut settings = json!({});
-        let added_pre = ensure_event_hook(&mut settings, PRE_TOOL_USE, "$HOME/.prempti/bin/codex-interceptor");
-        let added_pr = ensure_event_hook(&mut settings, PERMISSION_REQUEST, "$HOME/.prempti/bin/codex-interceptor");
+        let added_pre = ensure_event_hook(
+            &mut settings,
+            PRE_TOOL_USE,
+            "$HOME/.prempti/bin/codex-interceptor",
+        );
+        let added_pr = ensure_event_hook(
+            &mut settings,
+            PERMISSION_REQUEST,
+            "$HOME/.prempti/bin/codex-interceptor",
+        );
         assert!(added_pre);
         assert!(added_pr);
         assert!(settings["hooks"]["PreToolUse"].is_array());
@@ -475,8 +531,16 @@ mod tests {
                 }]
             }
         });
-        let added_pre = ensure_event_hook(&mut settings, PRE_TOOL_USE, "$HOME/.prempti/bin/codex-interceptor");
-        let added_pr = ensure_event_hook(&mut settings, PERMISSION_REQUEST, "$HOME/.prempti/bin/codex-interceptor");
+        let added_pre = ensure_event_hook(
+            &mut settings,
+            PRE_TOOL_USE,
+            "$HOME/.prempti/bin/codex-interceptor",
+        );
+        let added_pr = ensure_event_hook(
+            &mut settings,
+            PERMISSION_REQUEST,
+            "$HOME/.prempti/bin/codex-interceptor",
+        );
         assert!(!added_pre, "PreToolUse already had our hook");
         assert!(!added_pr, "PermissionRequest already had our hook");
     }
@@ -491,8 +555,15 @@ mod tests {
                 }]
             }
         });
-        let added_pre = ensure_event_hook(&mut settings, PRE_TOOL_USE, "$HOME/.prempti/bin/codex-interceptor");
-        assert!(added_pre, "user hook name must not block Prempti registration");
+        let added_pre = ensure_event_hook(
+            &mut settings,
+            PRE_TOOL_USE,
+            "$HOME/.prempti/bin/codex-interceptor",
+        );
+        assert!(
+            added_pre,
+            "user hook name must not block Prempti registration"
+        );
 
         let groups = settings["hooks"]["PreToolUse"].as_array().unwrap();
         assert_eq!(
@@ -523,8 +594,16 @@ mod tests {
                 }]
             }
         });
-        let added_pre = ensure_event_hook(&mut settings, PRE_TOOL_USE, "$HOME/.prempti/bin/codex-interceptor");
-        let added_pr = ensure_event_hook(&mut settings, PERMISSION_REQUEST, "$HOME/.prempti/bin/codex-interceptor");
+        let added_pre = ensure_event_hook(
+            &mut settings,
+            PRE_TOOL_USE,
+            "$HOME/.prempti/bin/codex-interceptor",
+        );
+        let added_pr = ensure_event_hook(
+            &mut settings,
+            PERMISSION_REQUEST,
+            "$HOME/.prempti/bin/codex-interceptor",
+        );
         assert!(!added_pre);
         assert!(added_pr, "PermissionRequest was missing, should be added");
         assert!(settings["hooks"]["PermissionRequest"].is_array());
@@ -544,7 +623,8 @@ mod tests {
                 }]
             }
         });
-        assert!(!has_owned_codex_interceptor_hook(&settings));
+        assert!(owned_commands_for_event(&settings, PRE_TOOL_USE, "").is_empty());
+        assert!(owned_commands_for_event(&settings, PERMISSION_REQUEST, "").is_empty());
     }
 
     #[test]
@@ -557,7 +637,7 @@ mod tests {
                 }]
             }
         });
-        assert!(has_owned_codex_interceptor_hook(&settings));
+        assert!(!owned_commands_for_event(&settings, PERMISSION_REQUEST, "").is_empty());
     }
 
     // ----- strip_owned_hooks: mixed-with-user preservation -----------
@@ -624,7 +704,10 @@ mod tests {
         });
         let removed = strip_owned_hooks(&mut settings, "$HOME/.prempti/bin/codex-interceptor");
         assert!(removed);
-        assert!(settings.get("hooks").is_none(), "both events should be empty: {settings}");
+        assert!(
+            settings.get("hooks").is_none(),
+            "both events should be empty: {settings}"
+        );
     }
 
     #[test]
@@ -726,5 +809,31 @@ mod tests {
         let removed = strip_owned_hooks(&mut settings, "$HOME/.prempti/bin/codex-interceptor");
         assert!(!removed);
         assert_eq!(settings, snapshot, "settings untouched");
+    }
+
+    #[test]
+    fn owned_commands_lists_interceptor_per_event() {
+        let settings = json!({
+            "hooks": {
+                "PreToolUse": [{"matcher": ".*", "hooks": [
+                    {"type": "command", "command": "$HOME/.prempti/bin/codex-interceptor"},
+                    {"type": "command", "command": "python user.py"}
+                ]}],
+                "PermissionRequest": [{"matcher": ".*", "hooks": [
+                    {"type": "command", "command": "/opt/prempti/bin/codex-interceptor"}
+                ]}]
+            }
+        });
+        let expected = "$HOME/.prempti/bin/codex-interceptor";
+        assert_eq!(
+            owned_commands_for_event(&settings, PRE_TOOL_USE, expected),
+            vec!["$HOME/.prempti/bin/codex-interceptor".to_string()]
+        );
+        assert_eq!(
+            owned_commands_for_event(&settings, PERMISSION_REQUEST, expected).len(),
+            1
+        );
+        // Absent event → empty.
+        assert!(owned_commands_for_event(&json!({"hooks": {}}), PRE_TOOL_USE, expected).is_empty());
     }
 }

--- a/tools/premptictl/src/logs_pretty.rs
+++ b/tools/premptictl/src/logs_pretty.rs
@@ -205,6 +205,10 @@ impl FsSessionNameResolver {
         let index_path = codex_session_index_path(transcript_path)?;
         let cur_len = std::fs::metadata(&index_path).ok().map(|m| m.len());
         let entry = self.codex.entry(index_path.clone()).or_default();
+        // When the index can't be stat'd (`cur_len` is None — missing or
+        // unreadable), we intentionally keep any last-known name rather than
+        // blank it: Codex appends to the index and never deletes it
+        // mid-session, so a transient stat failure shouldn't drop the label.
         if let Some(len) = cur_len {
             // The index is tiny and rename only appends; on any size change
             // we rebuild from scratch, which keeps "last line wins" trivial.
@@ -267,12 +271,15 @@ fn scan_transcript_incremental(path: &str, entry: &mut ResolverEntry) {
 
 /// Derive `<codex_home>/session_index.jsonl` from a Codex rollout transcript
 /// path shaped like `<codex_home>/sessions/YYYY/MM/DD/rollout-*.jsonl`. Splits
-/// on the `sessions` directory segment so a custom `CODEX_HOME` works, and
-/// handles both `/` and `\` separators. Returns `None` when the path has no
-/// `sessions` segment (i.e. it isn't a Codex rollout path).
+/// on the *last* `sessions` segment (`rfind`), so a custom `CODEX_HOME` that
+/// itself contains a `sessions` component still resolves correctly — the date
+/// and `rollout-*` components are never `sessions`, so the deepest match is
+/// always the real session dir. Handles both `/` and `\` separators. Returns
+/// `None` when the path has no `sessions` segment (i.e. it isn't a Codex
+/// rollout path).
 fn codex_session_index_path(transcript_path: &str) -> Option<String> {
     for sep in ["/sessions/", "\\sessions\\"] {
-        if let Some(idx) = transcript_path.find(sep) {
+        if let Some(idx) = transcript_path.rfind(sep) {
             let home = &transcript_path[..idx];
             let slash = &sep[..1];
             return Some(format!("{home}{slash}session_index.jsonl"));
@@ -2182,6 +2189,13 @@ mod tests {
             codex_session_index_path(r"C:\Users\u\.codex\sessions\2026\06\25\rollout-x.jsonl")
                 .as_deref(),
             Some(r"C:\Users\u\.codex\session_index.jsonl")
+        );
+        // A CODEX_HOME whose own path contains a `sessions` segment must still
+        // resolve to the deepest (real) session dir — `rfind`, not `find`.
+        assert_eq!(
+            codex_session_index_path("/home/sessions/.codex/sessions/2026/06/25/rollout-x.jsonl")
+                .as_deref(),
+            Some("/home/sessions/.codex/session_index.jsonl")
         );
         // Not a Codex rollout path → no index.
         assert_eq!(

--- a/tools/premptictl/src/logs_pretty.rs
+++ b/tools/premptictl/src/logs_pretty.rs
@@ -100,7 +100,20 @@ impl ShowMask {
 }
 
 pub trait SessionNameResolver {
-    fn resolve(&mut self, transcript_path: &str) -> Option<String>;
+    /// Resolve a human-friendly session name for display.
+    ///
+    /// `agent_name` selects the storage convention. Claude Code keeps the
+    /// name inside the transcript itself (a `custom-title` record written by
+    /// `/rename`, else the first user message). Codex never puts the name in
+    /// the transcript — it lives in `<codex_home>/session_index.jsonl`, keyed
+    /// by session id. `session_id` and `transcript_path` come straight from
+    /// the seen alert's `agent.session_id` / `agent.transcript_path`.
+    fn resolve(
+        &mut self,
+        agent_name: &str,
+        session_id: &str,
+        transcript_path: &str,
+    ) -> Option<String>;
 }
 
 #[derive(Default)]
@@ -124,13 +137,38 @@ impl ResolverEntry {
     }
 }
 
+/// Parsed `session_index.jsonl`, cached so we only re-read when the file
+/// changes. `names` maps session id → most-recent `thread_name`.
+#[derive(Default)]
+struct CodexIndexCache {
+    /// Byte length last read. Any change (grow on `/rename`, or shrink on
+    /// rotation) triggers a full rebuild.
+    last_len: u64,
+    names: HashMap<String, String>,
+}
+
 #[derive(Default)]
 pub struct FsSessionNameResolver {
+    /// Claude Code: incremental transcript-scan state, keyed by transcript path.
     cache: HashMap<String, ResolverEntry>,
+    /// Codex: parsed `session_index.jsonl`, keyed by index path.
+    codex: HashMap<String, CodexIndexCache>,
 }
 
 impl SessionNameResolver for FsSessionNameResolver {
-    fn resolve(&mut self, transcript_path: &str) -> Option<String> {
+    fn resolve(
+        &mut self,
+        agent_name: &str,
+        session_id: &str,
+        transcript_path: &str,
+    ) -> Option<String> {
+        // Codex doesn't write the session name into the transcript — it
+        // records it (auto-generated first, then overwritten by `/rename`) in
+        // `<codex_home>/session_index.jsonl`, keyed by session id.
+        if agent_name == "codex" {
+            return self.resolve_codex(session_id, transcript_path);
+        }
+        // Claude Code (default): the name lives in the transcript itself.
         if transcript_path.is_empty() {
             return None;
         }
@@ -148,6 +186,39 @@ impl SessionNameResolver for FsSessionNameResolver {
             }
         }
         entry.current()
+    }
+}
+
+impl FsSessionNameResolver {
+    /// Resolve a Codex session name from `<codex_home>/session_index.jsonl`.
+    /// The index path is derived from the rollout `transcript_path`
+    /// (`<codex_home>/sessions/YYYY/MM/DD/rollout-*.jsonl`), so a relocated
+    /// `CODEX_HOME` needs no extra wiring. Each `/rename` appends a fresh
+    /// `{"id":...,"thread_name":...}` line, so the last entry for a session id
+    /// wins. Best-effort: any miss (no index, no matching id, unparseable
+    /// line, future format change) falls back to the bare session id via
+    /// `None`.
+    fn resolve_codex(&mut self, session_id: &str, transcript_path: &str) -> Option<String> {
+        if session_id.is_empty() {
+            return None;
+        }
+        let index_path = codex_session_index_path(transcript_path)?;
+        let cur_len = std::fs::metadata(&index_path).ok().map(|m| m.len());
+        let entry = self.codex.entry(index_path.clone()).or_default();
+        if let Some(len) = cur_len {
+            // The index is tiny and rename only appends; on any size change
+            // we rebuild from scratch, which keeps "last line wins" trivial.
+            if len != entry.last_len {
+                entry.names.clear();
+                load_codex_index(&index_path, &mut entry.names);
+                entry.last_len = len;
+            }
+        }
+        entry
+            .names
+            .get(session_id)
+            .map(|name| condense_session_name(name))
+            .filter(|name| !name.is_empty())
     }
 }
 
@@ -191,6 +262,48 @@ fn scan_transcript_incremental(path: &str, entry: &mut ResolverEntry) {
             }
             _ => {}
         }
+    }
+}
+
+/// Derive `<codex_home>/session_index.jsonl` from a Codex rollout transcript
+/// path shaped like `<codex_home>/sessions/YYYY/MM/DD/rollout-*.jsonl`. Splits
+/// on the `sessions` directory segment so a custom `CODEX_HOME` works, and
+/// handles both `/` and `\` separators. Returns `None` when the path has no
+/// `sessions` segment (i.e. it isn't a Codex rollout path).
+fn codex_session_index_path(transcript_path: &str) -> Option<String> {
+    for sep in ["/sessions/", "\\sessions\\"] {
+        if let Some(idx) = transcript_path.find(sep) {
+            let home = &transcript_path[..idx];
+            let slash = &sep[..1];
+            return Some(format!("{home}{slash}session_index.jsonl"));
+        }
+    }
+    None
+}
+
+/// Read every `{"id":...,"thread_name":...}` line into `names`, last write
+/// winning so the most recent `/rename` for a session id is what survives.
+/// Silent on any I/O or parse error — this is a display nicety, not policy.
+fn load_codex_index(path: &str, names: &mut HashMap<String, String>) {
+    let Ok(file) = File::open(path) else {
+        return;
+    };
+    for line in BufReader::new(file).lines() {
+        let Ok(line) = line else { break };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<Value>(trimmed) else {
+            continue;
+        };
+        let (Some(id), Some(name)) = (
+            v.get("id").and_then(|x| x.as_str()),
+            v.get("thread_name").and_then(|x| x.as_str()),
+        ) else {
+            continue;
+        };
+        names.insert(id.to_string(), name.to_string());
     }
 }
 
@@ -516,6 +629,7 @@ impl<R: SessionNameResolver> Formatter<R> {
             .or_else(|| field_str(fields, "agent.cwd"))
             .unwrap_or_default();
         let transcript_path = field_str(fields, "agent.transcript_path").unwrap_or_default();
+        let agent_name = field_str(fields, "agent.name").unwrap_or_default();
         let time_str = clock_time_from_alert(seen);
 
         let mut out = Vec::new();
@@ -536,7 +650,9 @@ impl<R: SessionNameResolver> Formatter<R> {
 
         // Resolve title up front so we can both emit the banner and detect
         // mid-stream rename. Resolver re-scans the transcript incrementally.
-        let resolved_title = self.resolver.resolve(&transcript_path);
+        let resolved_title = self
+            .resolver
+            .resolve(&agent_name, &session_id, &transcript_path);
         if new_session {
             let banner = self.format_banner(&session_id, color_code, resolved_title.as_deref());
             self.last_banner_meta.push((
@@ -1004,12 +1120,8 @@ impl<RS: SessionNameResolver> SharedState<RS> {
     /// buffer, attaching banner regeneration metadata to the lines that
     /// `Formatter` flagged as banners. Caps at `EVENT_BUFFER_CAPACITY`.
     fn record_lines(&mut self, lines: &[String]) {
-        let banners: HashMap<usize, BannerMeta> = self
-            .formatter
-            .last_banner_meta()
-            .iter()
-            .cloned()
-            .collect();
+        let banners: HashMap<usize, BannerMeta> =
+            self.formatter.last_banner_meta().iter().cloned().collect();
         for (i, line) in lines.iter().enumerate() {
             let entry = match banners.get(&i) {
                 Some(meta) => BufferedLine::Banner(meta.clone()),
@@ -1181,7 +1293,10 @@ where
     let stdout = io::stdout();
     let mut out = stdout.lock();
     if with_status && s.status_drawn {
-        let rows = s.footer_size.map(|(_, r)| r).unwrap_or_else(|| detect_term_size().1);
+        let rows = s
+            .footer_size
+            .map(|(_, r)| r)
+            .unwrap_or_else(|| detect_term_size().1);
         leave_split_layout(&mut out, rows)?;
         writeln!(out)?;
     } else if final_summary {
@@ -1647,7 +1762,14 @@ mod tests {
 
     struct StubResolver(HashMap<String, String>);
     impl SessionNameResolver for StubResolver {
-        fn resolve(&mut self, transcript_path: &str) -> Option<String> {
+        // Keyed by transcript path; agent/session are irrelevant to the
+        // formatter-level tests that use this stub.
+        fn resolve(
+            &mut self,
+            _agent_name: &str,
+            _session_id: &str,
+            transcript_path: &str,
+        ) -> Option<String> {
             self.0.get(transcript_path).cloned()
         }
     }
@@ -1744,7 +1866,10 @@ mod tests {
         let joined = out.join("\n");
         assert!(joined.contains("[abc123]"));
         assert!(joined.contains("●"));
-        assert!(!joined.contains("◉"), "pass must not use the allow bullet: {joined}");
+        assert!(
+            !joined.contains("◉"),
+            "pass must not use the allow bullet: {joined}"
+        );
         assert!(joined.contains("Bash(ls -la)"));
         assert!(joined.contains("~/proj"));
         let c = f.counters();
@@ -1807,8 +1932,14 @@ mod tests {
         let seen = make_seen(5, "abc", "/home/u/proj", "Read", "file", "/etc/hosts");
         let out = f.process_line(&seen);
         let joined = out.join("\n");
-        assert!(joined.contains("◉"), "matched-allow bullet expected: {joined}");
-        assert!(!joined.contains("●"), "must not use the pass bullet: {joined}");
+        assert!(
+            joined.contains("◉"),
+            "matched-allow bullet expected: {joined}"
+        );
+        assert!(
+            !joined.contains("●"),
+            "must not use the pass bullet: {joined}"
+        );
         assert!(joined.contains("Read"), "tool name on event line: {joined}");
         assert!(
             joined.contains("│ /etc/hosts"),
@@ -2033,6 +2164,78 @@ mod tests {
     }
 
     #[test]
+    fn codex_index_path_derives_from_rollout_transcript() {
+        assert_eq!(
+            codex_session_index_path(
+                "/home/u/.codex/sessions/2026/06/25/rollout-2026-06-25T15-01-46-uuid.jsonl"
+            )
+            .as_deref(),
+            Some("/home/u/.codex/session_index.jsonl")
+        );
+        // A relocated CODEX_HOME is handled by splitting on `sessions`.
+        assert_eq!(
+            codex_session_index_path("/opt/cdx/sessions/2026/01/02/rollout-x.jsonl").as_deref(),
+            Some("/opt/cdx/session_index.jsonl")
+        );
+        // Windows separators.
+        assert_eq!(
+            codex_session_index_path(r"C:\Users\u\.codex\sessions\2026\06\25\rollout-x.jsonl")
+                .as_deref(),
+            Some(r"C:\Users\u\.codex\session_index.jsonl")
+        );
+        // Not a Codex rollout path → no index.
+        assert_eq!(
+            codex_session_index_path("/home/u/.claude/projects/x/abc.jsonl"),
+            None
+        );
+        assert_eq!(codex_session_index_path(""), None);
+    }
+
+    #[test]
+    fn codex_resolver_reads_last_thread_name_and_refreshes() {
+        // session_index.jsonl with two entries for the same id (an auto-name
+        // then a /rename) — the last one must win.
+        let dir = std::env::temp_dir().join(format!("prempti-codexidx-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let index = dir.join("session_index.jsonl");
+        let body = concat!(
+            "{\"id\":\"sid1\",\"thread_name\":\"Analyze project\",\"updated_at\":\"t1\"}\n",
+            "{\"id\":\"sid2\",\"thread_name\":\"Other\",\"updated_at\":\"t1\"}\n",
+            "{\"id\":\"sid1\",\"thread_name\":\"ciao ciao\",\"updated_at\":\"t2\"}\n",
+        );
+        std::fs::write(&index, body).unwrap();
+        // A rollout path under the same codex home — the file itself need not
+        // exist; only the derived index path is read.
+        let tpath = format!(
+            "{}/sessions/2026/06/25/rollout-x-sid1.jsonl",
+            dir.to_string_lossy()
+        );
+
+        let mut r = FsSessionNameResolver::default();
+        assert_eq!(
+            r.resolve("codex", "sid1", &tpath).as_deref(),
+            Some("ciao ciao"),
+            "last thread_name for the id must win"
+        );
+        assert_eq!(r.resolve("codex", "sid2", &tpath).as_deref(), Some("Other"));
+        // Unknown id, and a non-codex agent, both fall back to None.
+        assert_eq!(r.resolve("codex", "sid3", &tpath), None);
+        assert_eq!(r.resolve("claude_code", "sid1", &tpath), None);
+
+        // Appending a newer rename grows the file → resolver rebuilds.
+        let more = format!("{body}{{\"id\":\"sid1\",\"thread_name\":\"final name\"}}\n");
+        std::fs::write(&index, more).unwrap();
+        assert_eq!(
+            r.resolve("codex", "sid1", &tpath).as_deref(),
+            Some("final name"),
+            "resolver must pick up an appended rename"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn clock_time_uses_evt_time_when_available() {
         // 1700000000 = 2023-11-14 22:13:20 UTC. Local will vary by tz; just
         // assert format HH:MM:SS.
@@ -2082,7 +2285,10 @@ mod tests {
         let mut f = Formatter::new(opts, "/home/u".to_string(), StubResolver(HashMap::new()));
         let out = f.process_line(&make_seen(1, "s", "/home/u", "Bash", "command", "ls"));
         let joined = out.join("\n");
-        assert!(joined.contains("●"), "pass bullet expected via seen alias: {joined}");
+        assert!(
+            joined.contains("●"),
+            "pass bullet expected via seen alias: {joined}"
+        );
         assert_eq!(f.counters().pass, 1);
     }
 
@@ -2265,7 +2471,11 @@ mod tests {
         opts.term_cols = 120;
         let f = Formatter::new(opts, "/home/u".to_string(), StubResolver(HashMap::new()));
         let rule = f.status_footer()[1].clone();
-        assert_eq!(display_width(&rule), 120, "rule width != term_cols: {rule:?}");
+        assert_eq!(
+            display_width(&rule),
+            120,
+            "rule width != term_cols: {rule:?}"
+        );
     }
 
     #[test]
@@ -2329,7 +2539,10 @@ mod tests {
         // Reset DECSTBM (`ESC[r`) and park cursor at the bottom row so a
         // shell prompt appears below the (now-static) footer.
         assert!(out.contains("\x1b[r"), "missing region reset: {out:?}");
-        assert!(out.contains("\x1b[30;1H"), "missing bottom-row park: {out:?}");
+        assert!(
+            out.contains("\x1b[30;1H"),
+            "missing bottom-row park: {out:?}"
+        );
     }
 
     #[test]
@@ -2353,7 +2566,10 @@ mod tests {
         assert!(off < body && body < on, "toggle must bracket body: {out:?}");
         // Cursor parks at the events-region bottom (27) so the next event
         // writeln scrolls naturally.
-        assert!(out.ends_with("\x1b[27;1H"), "must park at events bottom: {out:?}");
+        assert!(
+            out.ends_with("\x1b[27;1H"),
+            "must park at events bottom: {out:?}"
+        );
     }
 
     fn make_state(cols: usize) -> SharedState<StubResolver> {
@@ -2381,7 +2597,10 @@ mod tests {
         // Scroll region established for the new height.
         assert!(out.contains("\x1b[1;47r"), "missing scroll region: {out:?}");
         // Footer absolute-positioned at the new bottom.
-        assert!(out.contains("\x1b[48;1H"), "missing footer top CUP: {out:?}");
+        assert!(
+            out.contains("\x1b[48;1H"),
+            "missing footer top CUP: {out:?}"
+        );
         // Rule sized to the new width.
         let rule_chars = out.matches('─').count();
         assert!(rule_chars >= 160, "rule sized to new width: {rule_chars}");
@@ -2405,11 +2624,17 @@ mod tests {
         state.full_repaint(&mut buf, 120, 30).unwrap();
         let out = String::from_utf8(buf).unwrap();
         for i in 0..3 {
-            assert!(out.contains(&format!("event-{i}")), "missing buffered line {i}: {out:?}");
+            assert!(
+                out.contains(&format!("event-{i}")),
+                "missing buffered line {i}: {out:?}"
+            );
         }
         // Most recent event right above the events region bottom (rows-3 = 27).
         // 3 events anchored to bottom: rows 25, 26, 27. Cursor jumps to row 25.
-        assert!(out.contains("\x1b[25;1H"), "events should anchor at row 25: {out:?}");
+        assert!(
+            out.contains("\x1b[25;1H"),
+            "events should anchor at row 25: {out:?}"
+        );
     }
 
     #[test]
@@ -2429,9 +2654,18 @@ mod tests {
         // events excluded.
         state.full_repaint(&mut buf, 120, 10).unwrap();
         let out = String::from_utf8(buf).unwrap();
-        assert!(out.contains("event-049"), "most recent must render: {out:?}");
-        assert!(out.contains("event-043"), "oldest visible must render: {out:?}");
-        assert!(!out.contains("event-042"), "off-screen oldest must NOT render: {out:?}");
+        assert!(
+            out.contains("event-049"),
+            "most recent must render: {out:?}"
+        );
+        assert!(
+            out.contains("event-043"),
+            "oldest visible must render: {out:?}"
+        );
+        assert!(
+            !out.contains("event-042"),
+            "off-screen oldest must NOT render: {out:?}"
+        );
     }
 
     #[test]
@@ -2440,11 +2674,13 @@ mod tests {
         // trailing dashes need to track the new width, not replay the width
         // they were originally written at.
         let mut state = make_state(120);
-        state.event_buffer.push_back(BufferedLine::Banner(BannerMeta {
-            session_id: "abcdef12".to_string(),
-            color_code: 1,
-            name: None,
-        }));
+        state
+            .event_buffer
+            .push_back(BufferedLine::Banner(BannerMeta {
+                session_id: "abcdef12".to_string(),
+                color_code: 1,
+                name: None,
+            }));
         let mut buf: Vec<u8> = Vec::new();
         state.full_repaint(&mut buf, 200, 30).unwrap();
         let out = String::from_utf8(buf).unwrap();
@@ -2452,7 +2688,10 @@ mod tests {
         // trailing pad. Total visible ─ count should be ≥ 200 (the new
         // width) since the banner extends to the new viewport.
         let dashes = out.matches('─').count();
-        assert!(dashes >= 200, "banner should regenerate to new width: {dashes}");
+        assert!(
+            dashes >= 200,
+            "banner should regenerate to new width: {dashes}"
+        );
     }
 
     #[test]

--- a/tools/premptictl/src/main.rs
+++ b/tools/premptictl/src/main.rs
@@ -1841,8 +1841,7 @@ mod default_action_tests {
     #[test]
     fn flips_value_preserving_indent() {
         let yaml = "plugins:\n  - name: coding_agent\n    init_config:\n      mode: guardrails\n      default_action: allow\n      http_port: 2802\n";
-        let out =
-            rewrite_default_action_in_yaml(yaml, "defer").expect("default_action line found");
+        let out = rewrite_default_action_in_yaml(yaml, "defer").expect("default_action line found");
         assert!(
             out.contains("      default_action: defer\n"),
             "indent preserved: {out}"
@@ -2004,7 +2003,9 @@ fn print_usage() {
     eprintln!();
     eprintln!("  default-action          Show the no-rule-match floor (guardrails mode)");
     eprintln!("  default-action allow    No matching rule → Prempti approves (skips agent prompt)");
-    eprintln!("  default-action defer    No matching rule → defer to the agent's own permission flow");
+    eprintln!(
+        "  default-action defer    No matching rule → defer to the agent's own permission flow"
+    );
     eprintln!();
     eprintln!("  start            Start the service");
     eprintln!("  stop             Stop the service");
@@ -2129,7 +2130,7 @@ fn main() {
     match cmd_args.as_slice() {
         ["hook", "add"] | ["hook", "add", "claude"] => hook::cli_add(&prefix),
         ["hook", "remove"] | ["hook", "remove", "claude"] => hook::cli_remove(&prefix),
-        ["hook", "status"] | ["hook", "status", "claude"] => hook::cli_status(),
+        ["hook", "status"] | ["hook", "status", "claude"] => hook::cli_status(&prefix),
         ["hook", "add", "codex"] => hook_codex::cli_add(&prefix),
         ["hook", "remove", "codex"] => hook_codex::cli_remove(&prefix),
         ["hook", "status", "codex"] => hook_codex::cli_status(&prefix),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area CI

/area ctl

> /area documentation

> /area installer

> /area interceptor

> /area plugin

> /area rules

> /area skills

> /area supervisor

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

 - hook status reports what's actually registered — interceptor path and event(s), flagging stale/foreign/duplicate entries or a missing binary. hook status codex also checks that both PreToolUse and PermissionRequest are mounted and warns on a half-registered state.
 - logs resolves Codex session names from ~/.codex/session_index.jsonl (thread_name, path derived from transcript_path), so /rename and auto-generated names render instead of a bare session id. Claude Code path unchanged; display-only.
 - Also: tightened is_registered() to owned-hook detection (fail-closed preserved); daemon::control tests skip instead of panic when the socket path can't bind (macOS SUN_LEN); docs updated.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

